### PR TITLE
Create `add` methods on initializers and attributes

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -28,7 +28,6 @@ from collections.abc import (
     Iterable,
     Iterator,
     Mapping,
-    MutableMapping,
     MutableSequence,
     Sequence,
 )

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -22,12 +22,12 @@ import os
 import sys
 import textwrap
 import typing
-from collections import OrderedDict
 from collections.abc import (
     Collection,
     Hashable,
     Iterable,
     Iterator,
+    Mapping,
     MutableMapping,
     MutableSequence,
     Sequence,
@@ -39,7 +39,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Mapping,
     NamedTuple,
     SupportsInt,
     Union,
@@ -1372,7 +1371,11 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
         self._inputs: tuple[Value | None, ...] = tuple(inputs)
         # Values belong to their defining nodes. The values list is immutable
         self._outputs: tuple[Value, ...] = self._create_outputs(num_outputs, outputs)
-        self._attributes: _graph_containers.Attributes = _graph_containers.Attributes(self, attributes)
+        if isinstance(attributes, Mapping):
+            attributes = tuple(attributes.values())
+        self._attributes: _graph_containers.Attributes = _graph_containers.Attributes(
+            attributes
+        )
         self._overload: str = overload
         # TODO(justinchuby): Potentially support a version range
         self._version: int | None = version
@@ -2925,6 +2928,8 @@ class Function(_protocols.FunctionProtocol, Sequence[Node], _display.PrettyPrint
         self._name = name
         self._overload = overload
         self._graph = graph
+        if isinstance(attributes, Mapping):
+            attributes = tuple(attributes.values())
         self._attributes = _graph_containers.Attributes(attributes)
 
     def identifier(self) -> _protocols.OperatorIdentifier:

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -2221,6 +2221,18 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
 
     @property
     def initializers(self) -> _graph_containers.GraphInitializers:
+        """The initializers of the graph as a ``MutableMapping[str, Value]``.
+
+        The keys are the names of the initializers. The values are the :class:`Value` objects.
+
+        This property additionally supports the ``add`` method, which takes a :class:`Value`
+        and adds it to the initializers if it is not already present.
+
+        .. note::
+            When setting an initializer with ``graph.initializers[key] = value``,
+            if the value does not have a name, it will be assigned ``key`` as its name.
+
+        """
         return self._initializers
 
     def register_initializer(self, value: Value) -> None:

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -874,6 +874,13 @@ class NodeTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             node.attributes[1] = _core.AttrInt64("test_attr", 1)
 
+    def test_init_accepts_attribute_mapping(self):
+        node = _core.Node(
+            "ai.onnx", "TestOp", inputs=(), attributes=[_core.AttrInt64("test_attr", 1)]
+        )
+        new_node = _core.Node("", "OtherOp", inputs=(), attributes=node.attributes)
+        self.assertEqual(new_node.attributes, node.attributes)
+
     # TODO(justinchuby): Test all methods
 
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -881,6 +881,97 @@ class NodeTest(unittest.TestCase):
         new_node = _core.Node("", "OtherOp", inputs=(), attributes=node.attributes)
         self.assertEqual(new_node.attributes, node.attributes)
 
+    def test_attributes_get_int(self):
+        node = _core.Node(
+            "ai.onnx", "TestOp", inputs=(), attributes=[_core.AttrInt64("test_attr", 1)]
+        )
+        self.assertEqual(node.attributes.get_int("test_attr"), 1)
+        self.assertIsNone(node.attributes.get_int("non_existent_attr"))
+        self.assertEqual(node.attributes.get_int("non_existent_attr", 42), 42)
+
+    def test_attributes_get_float(self):
+        node = _core.Node(
+            "ai.onnx", "TestOp", inputs=(), attributes=[_core.AttrFloat32("test_attr", 1.0)]
+        )
+        self.assertEqual(node.attributes.get_float("test_attr"), 1.0)
+        self.assertIsNone(node.attributes.get_float("non_existent_attr"))
+        self.assertEqual(node.attributes.get_float("non_existent_attr", 42.0), 42.0)
+
+    def test_attributes_get_string(self):
+        node = _core.Node(
+            "ai.onnx", "TestOp", inputs=(), attributes=[_core.AttrString("test_attr", "value")]
+        )
+        self.assertEqual(node.attributes.get_string("test_attr"), "value")
+        self.assertIsNone(node.attributes.get_string("non_existent_attr"))
+        self.assertEqual(node.attributes.get_string("non_existent_attr", "default"), "default")
+
+    def test_attributes_get_tensor(self):
+        tensor = ir.Tensor(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+        node = _core.Node(
+            "ai.onnx", "TestOp", inputs=(), attributes=[_core.AttrTensor("test_attr", tensor)]
+        )
+        np.testing.assert_equal(
+            node.attributes.get_tensor("test_attr").numpy(), tensor.numpy()
+        )
+        self.assertIsNone(node.attributes.get_tensor("non_existent_attr"))
+        np.testing.assert_equal(
+            node.attributes.get_tensor("non_existent_attr", tensor).numpy(), tensor.numpy()
+        )
+
+    def test_attributes_get_ints(self):
+        node = _core.Node(
+            "ai.onnx",
+            "TestOp",
+            inputs=(),
+            attributes=[_core.AttrInt64s("test_attr", [1, 2, 3])],
+        )
+        self.assertEqual(node.attributes.get_ints("test_attr"), [1, 2, 3])
+        self.assertIsNone(node.attributes.get_ints("non_existent_attr"))
+        self.assertEqual(node.attributes.get_ints("non_existent_attr", [42]), [42])
+
+    def test_attributes_get_floats(self):
+        node = _core.Node(
+            "ai.onnx",
+            "TestOp",
+            inputs=(),
+            attributes=[_core.AttrFloat32s("test_attr", [1.0, 2.0, 3.0])],
+        )
+        self.assertEqual(node.attributes.get_floats("test_attr"), [1.0, 2.0, 3.0])
+        self.assertIsNone(node.attributes.get_floats("non_existent_attr"))
+        self.assertEqual(node.attributes.get_floats("non_existent_attr", [42.0]), [42.0])
+
+    def test_attributes_get_strings(self):
+        node = _core.Node(
+            "ai.onnx",
+            "TestOp",
+            inputs=(),
+            attributes=[_core.AttrStrings("test_attr", ["a", "b", "c"])],
+        )
+        self.assertEqual(node.attributes.get_strings("test_attr"), ["a", "b", "c"])
+        self.assertIsNone(node.attributes.get_strings("non_existent_attr"))
+        self.assertEqual(
+            node.attributes.get_strings("non_existent_attr", ["default"]), ["default"]
+        )
+
+    def test_attributes_get_tensors(self):
+        tensor1 = ir.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        tensor2 = ir.Tensor(np.array([3.0, 4.0], dtype=np.float32))
+        node = _core.Node(
+            "ai.onnx",
+            "TestOp",
+            inputs=(),
+            attributes=[_core.AttrTensors("test_attr", [tensor1, tensor2])],
+        )
+        tensors = node.attributes.get_tensors("test_attr")
+        self.assertIsNotNone(tensors)
+        self.assertEqual(len(tensors), 2)
+        np.testing.assert_equal(tensors[0].numpy(), tensor1.numpy())
+        np.testing.assert_equal(tensors[1].numpy(), tensor2.numpy())
+        self.assertIsNone(node.attributes.get_tensors("non_existent_attr"))
+        np.testing.assert_equal(
+            node.attributes.get_tensors("non_existent_attr", [tensor1]), [tensor1]
+        )
+
     # TODO(justinchuby): Test all methods
 
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -1564,7 +1564,7 @@ class GraphContainersTest(unittest.TestCase):
         self.assertNotIn(self.value3, self.graph.outputs)
         self.assertIn(self.value3, outputs_copy)
 
-    def test_set_initializers(self):
+    def test_initializers_setitem(self):
         self.graph.initializers["initializer1"] = self.value3
         self.assertIn("initializer1", self.graph.initializers)
         self.assertTrue(self.value3.is_initializer())
@@ -1578,11 +1578,11 @@ class GraphContainersTest(unittest.TestCase):
         self.assertFalse(self.value3.is_initializer())
         self.assertIsNone(self.value3.graph)
 
-    def test_set_initializers_raises_when_key_does_not_match(self):
+    def test_initializers_setitem_raises_when_key_does_not_match(self):
         with self.assertRaisesRegex(ValueError, "does not match the name of the value"):
             self.graph.initializers["some_key"] = self.value3
 
-    def test_set_initializers_raises_when_it_belongs_to_another_graph(self):
+    def test_initializers_setitem_raises_when_it_belongs_to_another_graph(self):
         other_graph = _core.Graph(inputs=(), outputs=(), nodes=())
         other_graph.initializers["initializer1"] = self.value3
         with self.assertRaisesRegex(
@@ -1596,10 +1596,50 @@ class GraphContainersTest(unittest.TestCase):
         self.assertTrue(self.value3.is_initializer())
         self.assertIs(self.value3.graph, self.graph)
 
-    def test_set_initializers_raises_when_value_does_not_have_a_name(self):
+    def test_initializers_setitem_raises_when_value_does_not_have_a_name(self):
         self.value3.name = None
         with self.assertRaises(TypeError):
             self.graph.initializers[None] = self.value3
+
+        with self.assertRaisesRegex(ValueError, "cannot be an empty string"):
+            self.graph.initializers[""] = _core.Value(name="")
+
+    def test_initializers_setitem_checks_value_name_match(self):
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            self.graph.initializers["some_name"] = _core.Value(name="some_other_name")
+
+    def test_initializers_setitem_assigns_key_to_value_name_if_not_set(self):
+        value = _core.Value(name=None)
+        self.graph.initializers["some_name"] = value
+        self.assertEqual(value.name, "some_name")
+        self.assertIs(value, self.graph.initializers["some_name"])
+
+        value = _core.Value(name="")
+        self.graph.initializers["some_other_name"] = value
+        self.assertEqual(value.name, "some_other_name")
+        self.assertIs(value, self.graph.initializers["some_other_name"])
+
+    def test_initializers_setitem_checks_value_type(self):
+        with self.assertRaisesRegex(TypeError, "must be a Value object"):
+            self.graph.initializers["some_name"] = ir.tensor([1, 2, 3], name="some_tensor")
+
+    def test_initializers_setitem_raises_when_value_is_node_output(self):
+        node = ir.node("SomeOp", inputs=[])
+        with self.assertRaisesRegex(ValueError, "produced by a node"):
+            self.graph.initializers["some_name"] = node.outputs[0]
+
+    def test_initializers_add_checks_value_name(self):
+        # Initializers should always have a name
+        with self.assertRaisesRegex(ValueError, "cannot be an empty string"):
+            self.graph.initializers.add(_core.Value(name=""))
+
+        with self.assertRaisesRegex(TypeError, "must be a string"):
+            self.graph.initializers.add(_core.Value(name=None))
+
+    def test_initializers_add_checks_value_type(self):
+        # Initializers should be of type Value
+        with self.assertRaisesRegex(TypeError, "must be a Value object"):
+            self.graph.initializers.add(ir.tensor([1, 2, 3], name="some_tensor"))
 
     def test_delete_initializer(self):
         self.graph.initializers["initializer1"] = self.value3

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -861,6 +861,19 @@ class NodeTest(unittest.TestCase):
         node.domain = "ai.onnx"
         self.assertEqual(node.domain, "")
 
+    def test_attributes_add(self):
+        node = _core.Node("ai.onnx", "TestOp", inputs=())
+        node.attributes.add(_core.AttrInt64("test_attr", 1))
+        self.assertIn("test_attr", node.attributes)
+        self.assertEqual(node.attributes["test_attr"].value, 1)
+
+    def test_attributes_set_raise_with_type_error(self):
+        node = _core.Node("ai.onnx", "TestOp", inputs=())
+        with self.assertRaises(TypeError):
+            node.attributes["test_attr"] = 1
+        with self.assertRaises(TypeError):
+            node.attributes[1] = _core.AttrInt64("test_attr", 1)
+
     # TODO(justinchuby): Test all methods
 
 

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -6,17 +6,21 @@
 
 from __future__ import annotations
 
+from onnx_ir import _protocols
+
 __all__ = [
     "GraphInputs",
     "GraphOutputs",
 ]
 
 import collections
-from collections.abc import Iterable
-from typing import SupportsIndex
+from collections.abc import Iterable, Sequence
+from typing import SupportsIndex, TypeVar
 
 import onnx_ir
 from onnx_ir import _core
+
+T = TypeVar("T")
 
 
 class _GraphIO(collections.UserList["_core.Value"]):
@@ -289,3 +293,65 @@ class Attributes(collections.UserDict[str, "_core.Attr"]):
     def add(self, value: _core.Attr) -> None:
         """Add an attribute to the node."""
         self[value.name] = value
+
+    def get_int(self, key: str, default: T = None) -> int | T:
+        """Get the integer value of the attribute."""
+        if key in self:
+            return self[key].as_int()
+        return default
+
+    def get_float(self, key: str, default: T = None) -> float | T:
+        """Get the float value of the attribute."""
+        if key in self:
+            return self[key].as_float()
+        return default
+
+    def get_string(self, key: str, default: T = None) -> str | T:
+        """Get the string value of the attribute."""
+        if key in self:
+            return self[key].as_string()
+        return default
+
+    def get_tensor(self, key: str, default: T = None) -> _protocols.TensorProtocol | T:
+        """Get the tensor value of the attribute."""
+        if key in self:
+            return self[key].as_tensor()
+        return default
+
+    def get_graph(self, key: str, default: T = None) -> _core.Graph | T:
+        """Get the graph value of the attribute."""
+        if key in self:
+            return self[key].as_graph()
+        return default
+
+    def get_ints(self, key: str, default: T = None) -> Sequence[int] | T:
+        """Get the Sequence of integers from the attribute."""
+        if key in self:
+            return self[key].as_ints()
+        return default
+
+    def get_floats(self, key: str, default: T = None) -> Sequence[float] | T:
+        """Get the Sequence of floats from the attribute."""
+        if key in self:
+            return self[key].as_floats()
+        return default
+
+    def get_strings(self, key: str, default: T = None) -> Sequence[str] | T:
+        """Get the Sequence of strings from the attribute."""
+        if key in self:
+            return self[key].as_strings()
+        return default
+
+    def get_tensors(
+        self, key: str, default: T = None
+    ) -> Sequence[_protocols.TensorProtocol] | T:
+        """Get the Sequence of tensors from the attribute."""
+        if key in self:
+            return self[key].as_tensors()
+        return default
+
+    def get_graphs(self, key: str, default: T = None) -> Sequence[_core.Graph] | T:
+        """Get the Sequence of graphs from the attribute."""
+        if key in self:
+            return self[key].as_graphs()
+        return default

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -13,12 +13,10 @@ __all__ = [
 
 import collections
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Mapping, SupportsIndex
+from typing import SupportsIndex
 
 import onnx_ir
-
-if TYPE_CHECKING:
-    from onnx_ir import _core
+from onnx_ir import _core
 
 
 class _GraphIO(collections.UserList["_core.Value"]):
@@ -274,15 +272,11 @@ class GraphInitializers(collections.UserDict[str, "_core.Value"]):
         self[value.name] = value  # type: ignore[arg-type]
 
 
-class Attributes(collections.UserDict[str, _core.Attr]):
+class Attributes(collections.UserDict[str, "_core.Attr"]):
     """The attributes of a Node."""
-    def __init__(self, attrs: Iterable[_core.Attr] | Mapping[str, _core.Attr]):
-        super().__init__()
-        if isinstance(attrs, Mapping):
-            self.update(attrs)
-        else:
-            for attr in attrs:
-                self[attr.name] = attr
+
+    def __init__(self, attrs: Iterable[_core.Attr]):
+        super().__init__({attr.name: attr for attr in attrs})
 
     def __setitem__(self, key: str, value: _core.Attr) -> None:
         """Set an attribute for the node."""

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -11,14 +11,13 @@ __all__ = [
     "GraphOutputs",
 ]
 
-import logging
 import collections
+import logging
 from collections.abc import Iterable, Sequence
 from typing import SupportsIndex, TypeVar
 
 import onnx_ir
-from onnx_ir import _core
-from onnx_ir import _protocols
+from onnx_ir import _core, _protocols
 
 T = TypeVar("T")
 

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -294,49 +294,49 @@ class Attributes(collections.UserDict[str, "_core.Attr"]):
         """Add an attribute to the node."""
         self[value.name] = value
 
-    def get_int(self, key: str, default: T = None) -> int | T:
+    def get_int(self, key: str, default: T = None) -> int | T:  # type: ignore[assignment]
         """Get the integer value of the attribute."""
         if key in self:
             return self[key].as_int()
         return default
 
-    def get_float(self, key: str, default: T = None) -> float | T:
+    def get_float(self, key: str, default: T = None) -> float | T:  # type: ignore[assignment]
         """Get the float value of the attribute."""
         if key in self:
             return self[key].as_float()
         return default
 
-    def get_string(self, key: str, default: T = None) -> str | T:
+    def get_string(self, key: str, default: T = None) -> str | T:  # type: ignore[assignment]
         """Get the string value of the attribute."""
         if key in self:
             return self[key].as_string()
         return default
 
-    def get_tensor(self, key: str, default: T = None) -> _protocols.TensorProtocol | T:
+    def get_tensor(self, key: str, default: T = None) -> _protocols.TensorProtocol | T:  # type: ignore[assignment]
         """Get the tensor value of the attribute."""
         if key in self:
             return self[key].as_tensor()
         return default
 
-    def get_graph(self, key: str, default: T = None) -> _core.Graph | T:
+    def get_graph(self, key: str, default: T = None) -> _core.Graph | T:  # type: ignore[assignment]
         """Get the graph value of the attribute."""
         if key in self:
             return self[key].as_graph()
         return default
 
-    def get_ints(self, key: str, default: T = None) -> Sequence[int] | T:
+    def get_ints(self, key: str, default: T = None) -> Sequence[int] | T:  # type: ignore[assignment]
         """Get the Sequence of integers from the attribute."""
         if key in self:
             return self[key].as_ints()
         return default
 
-    def get_floats(self, key: str, default: T = None) -> Sequence[float] | T:
+    def get_floats(self, key: str, default: T = None) -> Sequence[float] | T:  # type: ignore[assignment]
         """Get the Sequence of floats from the attribute."""
         if key in self:
             return self[key].as_floats()
         return default
 
-    def get_strings(self, key: str, default: T = None) -> Sequence[str] | T:
+    def get_strings(self, key: str, default: T = None) -> Sequence[str] | T:  # type: ignore[assignment]
         """Get the Sequence of strings from the attribute."""
         if key in self:
             return self[key].as_strings()
@@ -344,13 +344,13 @@ class Attributes(collections.UserDict[str, "_core.Attr"]):
 
     def get_tensors(
         self, key: str, default: T = None
-    ) -> Sequence[_protocols.TensorProtocol] | T:
+    ) -> Sequence[_protocols.TensorProtocol] | T:  # type: ignore[assignment]
         """Get the Sequence of tensors from the attribute."""
         if key in self:
             return self[key].as_tensors()
         return default
 
-    def get_graphs(self, key: str, default: T = None) -> Sequence[_core.Graph] | T:
+    def get_graphs(self, key: str, default: T = None) -> Sequence[_core.Graph] | T:  # type: ignore[assignment]
         """Get the Sequence of graphs from the attribute."""
         if key in self:
             return self[key].as_graphs()

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -262,7 +262,7 @@ class GraphInitializers(collections.UserDict[str, "_core.Value"]):
             value.name = key
         elif key != value.name:
             raise ValueError(
-                f"Key '{key}' does not match the name of the value '{value.name}'"
+                f"Key '{key}' does not match the name of the value '{value.name}'. Please use the value.name as the key."
             )
         if value.producer() is not None:
             raise ValueError(

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -269,7 +269,7 @@ class GraphInitializers(collections.UserDict[str, "_core.Value"]):
 
     def add(self, value: _core.Value) -> None:
         """Add an initializer to the graph."""
-        self[value.name] = value  # type: ignore[arg-type]
+        self[value.name] = value  # type: ignore[index]
 
 
 class Attributes(collections.UserDict[str, "_core.Attr"]):

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -278,11 +278,11 @@ class Attributes(collections.UserDict[str, _core.Attr]):
     """The attributes of a Node."""
     def __init__(self, attrs: Iterable[_core.Attr] | Mapping[str, _core.Attr]):
         super().__init__()
-        # TODO: Check runtime
         if isinstance(attrs, Mapping):
             self.update(attrs)
-        for attr in attrs:
-            self[attr.name] = attr
+        else:
+            for attr in attrs:
+                self[attr.name] = attr
 
     def __setitem__(self, key: str, value: _core.Attr) -> None:
         """Set an attribute for the node."""
@@ -291,11 +291,6 @@ class Attributes(collections.UserDict[str, _core.Attr]):
         if not isinstance(value, _core.Attr):
             raise TypeError(f"Value must be an Attr, not {type(value)}")
         super().__setitem__(key, value)
-
-    def __getitem__(self, key: str | int) -> onnx_ir.Attr:
-        if type(key) is int:
-            return tuple(self.data.values())[key]
-        return super().__getitem__(key)
 
     def add(self, value: _core.Attr) -> None:
         """Add an attribute to the node."""

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -343,8 +343,8 @@ class Attributes(collections.UserDict[str, "_core.Attr"]):
         return default
 
     def get_tensors(
-        self, key: str, default: T = None
-    ) -> Sequence[_protocols.TensorProtocol] | T:  # type: ignore[assignment]
+        self, key: str, default: T = None  # type: ignore[assignment]
+    ) -> Sequence[_protocols.TensorProtocol] | T:
         """Get the Sequence of tensors from the attribute."""
         if key in self:
             return self[key].as_tensors()

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -343,7 +343,9 @@ class Attributes(collections.UserDict[str, "_core.Attr"]):
         return default
 
     def get_tensors(
-        self, key: str, default: T = None  # type: ignore[assignment]
+        self,
+        key: str,
+        default: T = None,  # type: ignore[assignment]
     ) -> Sequence[_protocols.TensorProtocol] | T:
         """Get the Sequence of tensors from the attribute."""
         if key in self:

--- a/src/onnx_ir/passes/common/inliner.py
+++ b/src/onnx_ir/passes/common/inliner.py
@@ -9,7 +9,7 @@ import dataclasses
 __all__ = ["InlinePass", "InlinePassResult"]
 
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 import onnx_ir as ir
 import onnx_ir.convenience as _ir_convenience
@@ -52,7 +52,7 @@ class _CopyReplace:
     def __init__(
         self,
         inliner: InlinePass,
-        attr_map: dict[str, ir.Attr],
+        attr_map: Mapping[str, ir.Attr],
         value_map: dict[ir.Value, ir.Value | None],
         metadata_props: dict[str, str],
         call_stack: CallStack,
@@ -96,6 +96,7 @@ class _CopyReplace:
             return attr
         assert attr.is_ref()
         ref_attr_name = attr.ref_attr_name
+        assert ref_attr_name is not None, "Reference attribute must have a name"
         if ref_attr_name in self._attr_map:
             ref_attr = self._attr_map[ref_attr_name]
             if not ref_attr.is_ref():
@@ -237,7 +238,7 @@ class InlinePass(ir.passes.InPlacePass):
                 )
 
         # Identify substitutions for both inputs and attributes of the function:
-        attributes: dict[str, ir.Attr] = node.attributes
+        attributes: Mapping[str, ir.Attr] = node.attributes
         default_attr_values = {
             attr.name: attr
             for attr in function.attributes.values()


### PR DESCRIPTION
1. It's now possible to do `node.attributes.add(ir.Attr(...))` to avoid having to get the name as a redundant step.
2. Also allow node attributes to be initialized with a dictionary
    - This way users do not have to use
    ```py
    ir.Node(attributes=node.attributes.values())
    ```
	when copying the node. Instead, it is possible to

    ```py
    ir.Node(attributes=node.attributes)
    ```
3. Implement get_* methods on attributes to make getting default attributes easier.

    Before
    ```py
    attr = node.attributes.get("attr")
    if attr is not None:
        value = attr.as_int()
    else:
        value = 42
    ```

    now

    ```py
    value = node.attributes.get_int("attr", 42)
    ```