### PR TITLE
Rename reuse job to make required

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -16,7 +16,7 @@ permissions:  # set top-level default permissions as security best practice
   contents: read
 
 jobs:
-  test:
+  reuse-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Previously it was called "test", which is too generic to make required.