### PR TITLE
Configure the do-not-merge bot

### DIFF
--- a/.github/do-not-merge.yml
+++ b/.github/do-not-merge.yml
@@ -1,0 +1,1 @@
+alwaysCreateStatusCheck: true


### PR DESCRIPTION
According to https://github.com/googleapis/repo-automation-bots/tree/main/packages/do-not-merge#configuration. So when a PR is tagged do not merge it will not be merged accidentally