### PR TITLE
Support initializers with onnxtext

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -17,6 +17,7 @@
     onnx_ir.from_proto
     onnx_ir.from_onnx_text
     onnx_ir.to_proto
+    onnx_ir.to_onnx_text
     onnx_ir.tensor
     onnx_ir.node
 ```

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -37,6 +37,7 @@ __all__ = [
     "deserialize_value_info_proto",
     # Serialization
     "to_proto",
+    "to_onnx_text",
     "serialize_attribute_into",
     "serialize_attribute",
     "serialize_dimension_into",
@@ -69,7 +70,7 @@ import numpy as np
 import onnx
 import onnx.external_data_helper
 
-from onnx_ir import _core, _enums, _protocols, _type_casting, _convenience
+from onnx_ir import _convenience, _core, _enums, _protocols, _type_casting
 
 if typing.TYPE_CHECKING:
     import google.protobuf.internal.containers as proto_containers

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -226,19 +226,19 @@ def from_onnx_text(
 
 
 def to_onnx_text(
-    model: _protocols.ModelProtocol, /, without_initializers: bool = False
+    model: _protocols.ModelProtocol, /, exclude_initializers: bool = False
 ) -> str:
     """Convert the IR model to the ONNX textual representation.
 
     Args:
         model: The IR model to convert.
-        without_initializers: If True, the initializers will not be included in the output.
+        exclude_initializers: If True, the initializers will not be included in the output.
 
     Returns:
         The ONNX textual representation of the model.
     """
     proto = serialize_model(model)
-    if without_initializers:
+    if exclude_initializers:
         del proto.graph.initializer[:]
     text = onnx.printer.to_text(proto)
     return text

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -198,6 +198,18 @@ def from_onnx_text(
     """Convert the ONNX textual representation to an IR model.
 
     Read more about the textual representation at: https://onnx.ai/onnx/repo-docs/Syntax.html
+
+    Args:
+        model_text: The ONNX textual representation of the model.
+        with_initializers: A mapping of initializer names to tensors. If provided, these tensors
+            will be added to the model as initializers. If a name does not exist in the model,
+            a ValueError will be raised.
+
+    Returns:
+        The IR model corresponding to the ONNX textual representation.
+
+    Raises:
+        ValueError: If a name in `with_initializers` does not exist in the model.
     """
     proto = onnx.parser.parse_model(model_text)
     model = deserialize_model(proto)
@@ -211,6 +223,25 @@ def from_onnx_text(
             initializer.const_value = tensor
             model.graph.register_initializer(initializer)
     return model
+
+
+def to_onnx_text(
+    model: _protocols.ModelProtocol, /, without_initializers: bool = False
+) -> str:
+    """Convert the IR model to the ONNX textual representation.
+
+    Args:
+        model: The IR model to convert.
+        without_initializers: If True, the initializers will not be included in the output.
+
+    Returns:
+        The ONNX textual representation of the model.
+    """
+    proto = serialize_model(model)
+    if without_initializers:
+        del proto.graph.initializer[:]
+    text = onnx.printer.to_text(proto)
+    return text
 
 
 @typing.overload

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -54,6 +54,25 @@ class ConvenienceFunctionsTest(unittest.TestCase):
     def test_to_proto(self, _: str, ir_object):
         serde.to_proto(ir_object)
 
+    def test_from_to_onnx_text(self):
+        model_text = """\
+<
+   ir_version: 7,
+   opset_import: ["" : 17]
+>
+agraph (float[1,4,512,512] input_x, float[1,4,512,64] input_y) => (float[4,512,512] reshape_x) {
+   [node_name] shape_a = Constant <value: tensor = int64[3] {4,512,512}> ()
+   reshape_x = Reshape (input_x, shape_a)
+}"""
+        self.maxDiff = None
+        model = serde.from_onnx_text(model_text)
+        self.assertIsInstance(model, ir.Model)
+        self.assertEqual(model.ir_version, 7)
+        self.assertEqual(len(model.graph.inputs), 2)
+        self.assertEqual(len(model.graph.outputs), 1)
+        onnx_text_roundtrip = serde.to_onnx_text(model)
+        self.assertEqual(model_text.strip(), onnx_text_roundtrip.strip())
+
 
 class TensorProtoTensorTest(unittest.TestCase):
     @parameterized.parameterized.expand(


### PR DESCRIPTION
### Enhancements to Serialization and Deserialization:

* **Added `to_onnx_text` method**: Introduced a new method in `src/onnx_ir/serde.py` to convert an IR model to ONNX textual representation. The method includes an option to exclude initializers from the output.
* **Extended `from_onnx_text` method**: Enhanced the existing method to support adding initializers to the model during deserialization using a mapping of names to tensors. This addition improves flexibility and usability.
