### PR TITLE
External data callback and ir.save fixes

### DIFF
--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -44,7 +44,7 @@ def save(
     format: str | None = None,
     external_data: str | os.PathLike | None = None,
     size_threshold_bytes: int = 256,
-    callback: Callable[[_protocols.TensorProtocol, _external_data.CallBackInfo], None]
+    callback: Callable[[_protocols.TensorProtocol, _external_data.CallbackInfo], None]
     | None = None,
 ) -> None:
     """Save an ONNX model to a file.
@@ -65,7 +65,7 @@ def save(
             with tqdm.tqdm() as pbar:
             total_set = False
 
-            def callback(tensor: ir.TensorProtocol, metadata: ir.external_data.CallBackInfo) -> None:
+            def callback(tensor: ir.TensorProtocol, metadata: ir.external_data.CallbackInfo) -> None:
                 nonlocal total_set
                 if not total_set:
                     pbar.total = metadata.total

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -65,7 +65,7 @@ def save(
             with tqdm.tqdm() as pbar:
             total_set = False
 
-            def callback(tensor: ir.TensorProtocol, metadata):
+            def callback(tensor: ir.TensorProtocol, metadata: ir.external_data.CallBackInfo) -> None:
                 nonlocal total_set
                 if not total_set:
                     pbar.total = metadata.total

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -54,6 +54,30 @@ def save(
     to load the newly saved model, or provide a different external data path that
     is not currently referenced by any tensors in the model.
 
+    .. tip::
+
+        A simple progress bar can be implemented by passing a callback function as the following::
+
+            import onnx_ir as ir
+            import tqdm
+
+            with tqdm.tqdm() as pbar:
+            total_set = False
+
+            def callback(tensor: ir.TensorProtocol, metadata: dict):
+                nonlocal total_set
+                if not total_set:
+                    pbar.total = metadata["total"]
+                    total_set = True
+
+                pbar.update()
+                pbar.set_description(f"Saving {tensor.name} ({tensor.dtype}, {tensor.shape})")
+
+            ir.save(
+                ...,
+                callback=callback,
+            )
+
     Args:
         model: The model to save.
         path: The path to save the model to. E.g. "model.onnx".
@@ -69,7 +93,10 @@ def save(
             Effective only when ``external_data`` is set.
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes. The keys for the metadata dictionary are
-            "total", "index", "offset", and "size_bytes".
+
+            - ``"total"`` (the total number of tensors to save),
+            - ``"index"`` (the index of the tensor being saved),
+            - ``"offset"`` (the offset of the tensor in the external data file)
 
     Raises:
         ValueError: If the external data path is an absolute path.

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -109,11 +109,12 @@ def save(
         base_dir = os.path.dirname(path)
 
         # Store the original initializer values so they can be restored if modify_model=False
-        initializer_values: dict[_core.Graph, tuple[_core.Value, ...]] = {}
-        tensors: dict[_core.Graph, list[_protocols.TensorProtocol | None]] = {}
+        initializer_values: list[_core.Value] = []
+        tensors: list[_protocols.TensorProtocol | None] = []
         for graph in model.graphs():
-            initializer_values[graph] = tuple(model.graph.initializers.values())
-            tensors[graph] = [v.const_value for v in model.graph.initializers.values()]
+            # Collect from all subgraphs as well
+            initializer_values.extend(graph.initializers.values())
+            tensors.extend([v.const_value for v in graph.initializers.values()])
 
         try:
             model = _external_data.unload_from_model(
@@ -128,11 +129,8 @@ def save(
 
         finally:
             # Restore the original initializer values so the model is unchanged
-            for graph in model.graphs():
-                for initializer, tensor in zip(
-                    initializer_values[graph], tensors[graph], strict=True
-                ):
-                    initializer.const_value = tensor
+            for initializer, tensor in zip(initializer_values, tensors, strict=True):
+                initializer.const_value = tensor
 
     else:
         proto = serde.serialize_model(model)

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -63,21 +63,21 @@ def save(
             import tqdm
 
             with tqdm.tqdm() as pbar:
-            total_set = False
-
-            def callback(tensor: ir.TensorProtocol, metadata: ir.external_data.CallbackInfo) -> None:
-                nonlocal total_set
-                if not total_set:
-                    pbar.total = metadata.total
-                    total_set = True
-
-                pbar.update()
-                pbar.set_description(f"Saving {tensor.name} ({tensor.dtype}, {tensor.shape}) at offset {metadata.offset}")
-
-            ir.save(
-                ...,
-                callback=callback,
-            )
+                total_set = False
+    
+                def callback(tensor: ir.TensorProtocol, metadata: ir.external_data.CallbackInfo) -> None:
+                    nonlocal total_set
+                    if not total_set:
+                        pbar.total = metadata.total
+                        total_set = True
+    
+                    pbar.update()
+                    pbar.set_description(f"Saving {tensor.name} ({tensor.dtype}, {tensor.shape}) at offset {metadata.offset}")
+    
+                ir.save(
+                    ...,
+                    callback=callback,
+                )
 
     Args:
         model: The model to save.

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -110,11 +110,10 @@ def save(
 
         # Store the original initializer values so they can be restored if modify_model=False
         initializer_values: list[_core.Value] = []
-        tensors: list[_protocols.TensorProtocol | None] = []
         for graph in model.graphs():
             # Collect from all subgraphs as well
             initializer_values.extend(graph.initializers.values())
-            tensors.extend([v.const_value for v in graph.initializers.values()])
+        tensors = [v.const_value for v in initializer_values]
 
         try:
             model = _external_data.unload_from_model(

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 __all__ = ["load", "save"]
 
 import os
-from typing import Callable
+from typing import Any, Callable
 
 import onnx
 
@@ -44,7 +44,7 @@ def save(
     format: str | None = None,
     external_data: str | os.PathLike | None = None,
     size_threshold_bytes: int = 256,
-    callback: Callable[[_protocols.TensorProtocol], None] | None = None,
+    callback: Callable[[_protocols.TensorProtocol, dict[str, Any]], None] | None = None,
 ) -> None:
     """Save an ONNX model to a file.
 
@@ -68,7 +68,8 @@ def save(
         size_threshold_bytes: Save to external data if the tensor size in bytes is larger than this threshold.
             Effective only when ``external_data`` is set.
         callback: A callback function that is called for each tensor that is saved to external data
-            for debugging or logging purposes.
+            for debugging or logging purposes. The keys for the metadata dictionary are
+            "total", "index", "offset", and "size_bytes".
 
     Raises:
         ValueError: If the external data path is an absolute path.

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -64,16 +64,16 @@ def save(
 
             with tqdm.tqdm() as pbar:
                 total_set = False
-    
+
                 def callback(tensor: ir.TensorProtocol, metadata: ir.external_data.CallbackInfo) -> None:
                     nonlocal total_set
                     if not total_set:
                         pbar.total = metadata.total
                         total_set = True
-    
+
                     pbar.update()
                     pbar.set_description(f"Saving {tensor.name} ({tensor.dtype}, {tensor.shape}) at offset {metadata.offset}")
-    
+
                 ir.save(
                     ...,
                     callback=callback,

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 __all__ = ["load", "save"]
 
 import os
+from typing import Callable
 
 import onnx
 
-from onnx_ir import _core, serde
+from onnx_ir import _core, _protocols, serde
 from onnx_ir import external_data as _external_data
 from onnx_ir._polyfill import zip
 
@@ -43,6 +44,7 @@ def save(
     format: str | None = None,
     external_data: str | os.PathLike | None = None,
     size_threshold_bytes: int = 256,
+    callback: Callable[[_protocols.TensorProtocol], None] | None = None,
 ) -> None:
     """Save an ONNX model to a file.
 
@@ -65,6 +67,8 @@ def save(
             it will be serialized in the ONNX Proto message.
         size_threshold_bytes: Save to external data if the tensor size in bytes is larger than this threshold.
             Effective only when ``external_data`` is set.
+        callback: A callback function that is called for each tensor that is saved to external data
+            for debugging or logging purposes.
 
     Raises:
         ValueError: If the external data path is an absolute path.
@@ -77,12 +81,17 @@ def save(
         base_dir = os.path.dirname(path)
 
         # Store the original initializer values so they can be restored if modify_model=False
+        # FIXME(justinchuby): Get the initializers from subgraphs as well
         initializer_values = tuple(model.graph.initializers.values())
         tensors = [v.const_value for v in initializer_values]
 
         try:
             model = _external_data.unload_from_model(
-                model, base_dir, external_data, size_threshold_bytes=size_threshold_bytes
+                model,
+                base_dir,
+                external_data,
+                size_threshold_bytes=size_threshold_bytes,
+                callback=callback,
             )
             proto = serde.serialize_model(model)
             onnx.save(proto, path, format=format)

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -12,7 +12,7 @@ __all__ = [
     "load_to_model",
     "convert_tensors_to_external",
     "convert_tensors_from_external",
-    "CallBackInfo",
+    "CallbackInfo",
 ]
 
 import dataclasses
@@ -52,7 +52,7 @@ class _ExternalDataInfo:
 
 
 @dataclasses.dataclass
-class CallBackInfo:
+class CallbackInfo:
     """A class that shares information about a tensor that is to be saved as external data for callback functions.
 
     Attributes:
@@ -175,7 +175,7 @@ def _write_external_data(
     tensors: Sequence[_protocols.TensorProtocol],
     external_data_infos: Sequence[_ExternalDataInfo],
     file_path: str | os.PathLike,
-    callback: Callable[[_protocols.TensorProtocol, CallBackInfo], None] | None = None,
+    callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
 ) -> None:
     """Write tensor data to an external file according to information stored in ExternalDataInfo objects.
 
@@ -197,7 +197,7 @@ def _write_external_data(
             if callback is not None:
                 callback(
                     tensor,
-                    CallBackInfo(
+                    CallbackInfo(
                         total=tensors_count,
                         index=i,
                         offset=tensor_info.offset,
@@ -261,7 +261,7 @@ def convert_tensors_to_external(
     tensors: Sequence[_protocols.TensorProtocol],
     base_dir: str | os.PathLike,
     relative_path: str | os.PathLike,
-    callback: Callable[[_protocols.TensorProtocol, CallBackInfo], None] | None = None,
+    callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
 ) -> list[_core.ExternalTensor]:
     """Convert a sequence of any TensorProtocol tensors to external tensors.
 
@@ -372,7 +372,7 @@ def unload_from_model(
     relative_path: str | os.PathLike,
     *,
     size_threshold_bytes: int = 0,
-    callback: Callable[[_protocols.TensorProtocol, CallBackInfo], None] | None = None,
+    callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
 ) -> _core.Model:
     """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to a single data file.
 

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -159,7 +159,7 @@ def _write_external_data(
     tensors: Sequence[_protocols.TensorProtocol],
     external_data_infos: Sequence[_ExternalDataInfo],
     file_path: str | os.PathLike,
-    callback: Callable[[_protocols.TensorProtocol], None] | None = None,
+    callback: Callable[[_protocols.TensorProtocol, int, int], None] | None = None,
 ) -> None:
     """Write tensor data to an external file according to information stored in ExternalDataInfo objects.
 
@@ -170,13 +170,14 @@ def _write_external_data(
         callback: Optional callback function that is called for each tensor before writing to file
             for debugging or logging purposes.
     """
-    assert len(tensors) == len(external_data_infos), (
+    tensors_count = len(tensors)
+    assert tensors_count == len(external_data_infos), (
         "Number of tensors and external data infos should match"
     )
     with open(file_path, "wb") as data_file:
-        for tensor, tensor_info in zip(tensors, external_data_infos, strict=True):
+        for i, (tensor, tensor_info) in enumerate(zip(tensors, external_data_infos, strict=True)):
             if callback is not None:
-                callback(tensor)
+                callback(tensor, tensors_count, i)
             current_offset = tensor_info.offset
             assert tensor is not None
             raw_data = tensor.tobytes()
@@ -235,7 +236,7 @@ def convert_tensors_to_external(
     tensors: Sequence[_protocols.TensorProtocol],
     base_dir: str | os.PathLike,
     relative_path: str | os.PathLike,
-    callback: Callable[[_protocols.TensorProtocol], None] | None = None,
+    callback: Callable[[_protocols.TensorProtocol, int, int], None] | None = None,
 ) -> list[_core.ExternalTensor]:
     """Convert a sequence of any TensorProtocol tensors to external tensors.
 
@@ -346,7 +347,7 @@ def unload_from_model(
     relative_path: str | os.PathLike,
     *,
     size_threshold_bytes: int = 0,
-    callback: Callable[[_protocols.TensorProtocol], None] | None = None,
+    callback: Callable[[_protocols.TensorProtocol, int, int], None] | None = None,
 ) -> _core.Model:
     """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to a single data file.
 

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -411,6 +411,7 @@ def unload_from_model(
         [v.const_value for v in initializers_to_become_external],  # type: ignore[misc]
         base_dir=base_dir,
         relative_path=relative_path,
+        callback=callback,
     )
 
     # Replace the initializer values with external tensors and save the model

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -167,9 +167,12 @@ def _write_external_data(
         tensors: Tensors to be written as external data.
         external_data_infos: External data information stored for each tensor to be written as external data.
         file_path: Location to which external data is to be stored.
-        callback: Optional callback function that is called for each tensor before writing to file
+        callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes. The keys for the metadata dictionary are
-            "total", "index", "offset", and "size_bytes".
+
+            - ``"total"`` (the total number of tensors to save),
+            - ``"index"`` (the index of the tensor being saved),
+            - ``"offset"`` (the offset of the tensor in the external data file)
     """
     tensors_count = len(tensors)
     assert tensors_count == len(external_data_infos), (
@@ -258,9 +261,12 @@ def convert_tensors_to_external(
         tensors: Tensors to be converted to external tensors. They can be external tensors themselves.
         base_dir: Path of base directory.
         relative_path: Path to which external data is to be stored, relative to the ONNX file.
-        callback: Optional callback function that is called for each tensor before writing to file
+        callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes. The keys for the metadata dictionary are
-            "total", "index", "offset", and "size_bytes".
+
+            - ``"total"`` (the total number of tensors to save),
+            - ``"index"`` (the index of the tensor being saved),
+            - ``"offset"`` (the offset of the tensor in the external data file)
 
     Returns:
         A list of external tensors derived from a list of input tensors. The order
@@ -380,9 +386,12 @@ def unload_from_model(
         relative_path: Path to which external data is to be stored, relative to the ONNX file.
             E.g. "model.data"
         size_threshold_bytes: Save to external data if the tensor size in bytes is larger than this threshold.
-        callback: Optional callback function that is called for each tensor before writing to file
+        callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes. The keys for the metadata dictionary are
-            "total", "index", "offset", and "size_bytes".
+
+            - ``"total"`` (the total number of tensors to save),
+            - ``"index"`` (the index of the tensor being saved),
+            - ``"offset"`` (the offset of the tensor in the external data file)
 
     Returns:
         An ir.Model with all initializer data equal or above ``size_threshold_bytes``


### PR DESCRIPTION
This pull request introduces a new feature to the ONNX IR library by adding support for a callback function in several methods. The callback allows users to debug or log information about tensors being saved to external data files (or enable a progress bar). Additionally, minor improvements to code organization and comments are included.

![image](https://github.com/user-attachments/assets/0ced1a65-5235-469d-8053-2fa93116986a)
