### PR TITLE
Support numpy scalars in `Tensor`

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -417,6 +417,9 @@ class Tensor(TensorBase, _protocols.TensorProtocol, Generic[TArrayCompatible]): 
         else:
             self._shape = shape
             self._shape.freeze()
+        if isinstance(value, np.generic):
+            # Turn numpy scalar into a numpy array
+            value = np.array(value)
         if dtype is None:
             if isinstance(value, np.ndarray):
                 self._dtype = _enums.DataType.from_numpy(value.dtype)


### PR DESCRIPTION
Numpy scalars (https://numpy.org/doc/2.2/reference/arrays.scalars.html) have `__array__` defined but doesn't behave like normal np arrays sometimes. This change updates the initialization logic in `Tensor` to detect them and turn them into np.ndarray.

Fixes https://github.com/onnx/ir-py/issues/101.