### PR TITLE
Fix 4bit tensor unpacking

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1071,15 +1071,7 @@ class PackedTensor(TensorBase, _protocols.TensorProtocol, Generic[TArrayCompatib
         """
         array = self.numpy_packed()
         # ONNX IR returns the unpacked arrays
-        if self.dtype == _enums.DataType.INT4:
-            return _type_casting.unpack_int4(array, self.shape.numpy())
-        if self.dtype == _enums.DataType.UINT4:
-            return _type_casting.unpack_uint4(array, self.shape.numpy())
-        if self.dtype == _enums.DataType.FLOAT4E2M1:
-            return _type_casting.unpack_float4e2m1(array, self.shape.numpy())
-        raise TypeError(
-            f"PackedTensor only supports INT4, UINT4, FLOAT4E2M1, but got {self.dtype}"
-        )
+        return _type_casting.unpack_4bitx2(array, self.shape.numpy()).view(self.dtype.numpy())
 
     def numpy_packed(self) -> npt.NDArray[np.uint8]:
         """Return the tensor as a packed array."""

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -682,7 +682,9 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
 
         if self.dtype.bitwidth == 4:
             # Unpack the 4bit arrays
-            self._array = _type_casting.unpack_4bitx2(self._array, shape).view(self.dtype.numpy())
+            self._array = _type_casting.unpack_4bitx2(self._array, shape).view(
+                self.dtype.numpy()
+            )
         else:
             self._array = self._array.reshape(shape)
 

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -657,15 +657,13 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             self._array = np.empty(self.shape.numpy(), dtype=self.dtype.numpy())
             return
         # Map the whole file into the memory
-        # TODO(justinchuby): Verify if this would exhaust the memory address space
         with open(self.path, "rb") as f:
             self.raw = mmap.mmap(
                 f.fileno(),
                 0,
                 access=mmap.ACCESS_READ,
             )
-        # Handle the byte order correctly by always using little endian
-        dt = np.dtype(self.dtype.numpy()).newbyteorder("<")
+
         if self.dtype in {
             _enums.DataType.INT4,
             _enums.DataType.UINT4,
@@ -675,16 +673,16 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             dt = np.dtype(np.uint8).newbyteorder("<")
             count = self.size // 2 + self.size % 2
         else:
+            # Handle the byte order correctly by always using little endian
+            dt = np.dtype(self.dtype.numpy()).newbyteorder("<")
             count = self.size
+
         self._array = np.frombuffer(self.raw, dtype=dt, offset=self.offset or 0, count=count)
         shape = self.shape.numpy()
-        if self.dtype == _enums.DataType.INT4:
-            # Unpack the int4 arrays
-            self._array = _type_casting.unpack_int4(self._array, shape)
-        elif self.dtype == _enums.DataType.UINT4:
-            self._array = _type_casting.unpack_uint4(self._array, shape)
-        elif self.dtype == _enums.DataType.FLOAT4E2M1:
-            self._array = _type_casting.unpack_float4e2m1(self._array, shape)
+
+        if self.dtype.bitwidth == 4:
+            # Unpack the 4bit arrays
+            self._array = _type_casting.unpack_4bitx2(self._array, shape).view(self.dtype.numpy())
         else:
             self._array = self._array.reshape(shape)
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -2082,7 +2082,7 @@ class PackedTensorTest(unittest.TestCase):
         )
         np.testing.assert_array_equal(
             tensor.numpy(),
-            _type_casting._unpack_uint4_as_uint8(
+            _type_casting.unpack_4bitx2(
                 packed_data.numpy(force=True).view(np.uint8), dims=[2, 4]
             ).view(dtype.numpy()),
         )

--- a/src/onnx_ir/_type_casting.py
+++ b/src/onnx_ir/_type_casting.py
@@ -26,9 +26,7 @@ def pack_4bitx2(array: np.ndarray) -> npt.NDArray[np.uint8]:
     return array_flat[0::2] | array_flat[1::2]  # type: ignore[return-type]
 
 
-def unpack_4bitx2(
-    data: npt.NDArray[np.uint8], dims: Sequence[int]
-) -> npt.NDArray[np.uint8]:
+def unpack_4bitx2(data: npt.NDArray[np.uint8], dims: Sequence[int]) -> npt.NDArray[np.uint8]:
     """Convert a packed uint4 array to unpacked uint4 array represented as uint8.
 
     Args:

--- a/src/onnx_ir/_type_casting.py
+++ b/src/onnx_ir/_type_casting.py
@@ -1,14 +1,12 @@
 # Copyright (c) ONNX Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 """Numpy utilities for non-native type operation."""
-# TODO(justinchuby): Upstream the logic to onnx
 
 from __future__ import annotations
 
 import typing
 from collections.abc import Sequence
 
-import ml_dtypes
 import numpy as np
 
 if typing.TYPE_CHECKING:
@@ -28,7 +26,7 @@ def pack_4bitx2(array: np.ndarray) -> npt.NDArray[np.uint8]:
     return array_flat[0::2] | array_flat[1::2]  # type: ignore[return-type]
 
 
-def _unpack_uint4_as_uint8(
+def unpack_4bitx2(
     data: npt.NDArray[np.uint8], dims: Sequence[int]
 ) -> npt.NDArray[np.uint8]:
     """Convert a packed uint4 array to unpacked uint4 array represented as uint8.
@@ -52,56 +50,3 @@ def _unpack_uint4_as_uint8(
         result = result[:-1]
     result.resize(dims, refcheck=False)
     return result
-
-
-def unpack_uint4(
-    data: npt.NDArray[np.uint8], dims: Sequence[int]
-) -> npt.NDArray[ml_dtypes.uint4]:
-    """Convert a packed uint4 array to unpacked uint4 array represented as uint8.
-
-    Args:
-        data: A numpy array.
-        dims: The dimensions are used to reshape the unpacked buffer.
-
-    Returns:
-        A numpy array of int8/uint8 reshaped to dims.
-    """
-    return _unpack_uint4_as_uint8(data, dims).view(ml_dtypes.uint4)
-
-
-def _extend_int4_sign_bits(x: npt.NDArray[np.uint8]) -> npt.NDArray[np.int8]:
-    """Extend 4-bit signed integer to 8-bit signed integer."""
-    return np.where((x >> 3) == 0, x, x | 0xF0).astype(np.int8)
-
-
-def unpack_int4(
-    data: npt.NDArray[np.uint8], dims: Sequence[int]
-) -> npt.NDArray[ml_dtypes.int4]:
-    """Convert a packed (signed) int4 array to unpacked int4 array represented as int8.
-
-    The sign bit is extended to the most significant bit of the int8.
-
-    Args:
-        data: A numpy array.
-        dims: The dimensions are used to reshape the unpacked buffer.
-
-    Returns:
-        A numpy array of int8 reshaped to dims.
-    """
-    unpacked = _unpack_uint4_as_uint8(data, dims)
-    return _extend_int4_sign_bits(unpacked).view(ml_dtypes.int4)
-
-
-def unpack_float4e2m1(
-    data: npt.NDArray[np.uint8], dims: Sequence[int]
-) -> npt.NDArray[ml_dtypes.float4_e2m1fn]:
-    """Convert a packed float4e2m1 array to unpacked float4e2m1 array.
-
-    Args:
-        data: A numpy array.
-        dims: The dimensions are used to reshape the unpacked buffer.
-
-    Returns:
-        A numpy array of float32 reshaped to dims.
-    """
-    return _unpack_uint4_as_uint8(data, dims).view(ml_dtypes.float4_e2m1fn)

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -74,7 +74,6 @@ from onnx_ir import _convenience, _core, _enums, _protocols, _type_casting
 
 if typing.TYPE_CHECKING:
     import google.protobuf.internal.containers as proto_containers
-    import numpy.typing as npt
 
 logger = logging.getLogger(__name__)
 
@@ -389,7 +388,9 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
         if self._proto.HasField("raw_data"):
             array = np.frombuffer(self._proto.raw_data, dtype=dtype.numpy().newbyteorder("<"))
             if dtype.bitwidth == 4:
-                return _type_casting.unpack_4bitx2(array.astype(np.uint8), shape)
+                return _type_casting.unpack_4bitx2(array.astype(np.uint8), shape).voew(
+                    dtype.numpy()
+                )
             return array.reshape(shape)
         if dtype == _enums.DataType.STRING:
             return np.array(self._proto.string_data).reshape(self._proto.dims)
@@ -418,7 +419,9 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
             if dtype.bitwidth == 8:
                 return array.astype(np.uint8).view(dtype.numpy())
             if dtype.bitwidth == 4:
-                return _type_casting.unpack_4bitx2(array.astype(np.uint8), self._proto.dims).view(dtype.numpy())
+                return _type_casting.unpack_4bitx2(
+                    array.astype(np.uint8), self._proto.dims
+                ).view(dtype.numpy())
             raise ValueError(
                 f"Unsupported dtype {dtype} for int32_data with bitwidth {dtype.bitwidth}"
             )

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -388,7 +388,7 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
         if self._proto.HasField("raw_data"):
             array = np.frombuffer(self._proto.raw_data, dtype=dtype.numpy().newbyteorder("<"))
             if dtype.bitwidth == 4:
-                return _type_casting.unpack_4bitx2(array.astype(np.uint8), shape).voew(
+                return _type_casting.unpack_4bitx2(array.astype(np.uint8), shape).view(
                     dtype.numpy()
                 )
             return array.reshape(shape)

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -397,19 +397,21 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
             return np.array(self._proto.string_data).reshape(shape)
         if self._proto.int32_data:
             assert dtype in {
-                _enums.DataType.INT32,
-                _enums.DataType.INT16,
-                _enums.DataType.UINT16,
-                _enums.DataType.INT8,
-                _enums.DataType.UINT8,
+                _enums.DataType.BFLOAT16,
                 _enums.DataType.BOOL,
+                _enums.DataType.FLOAT16,
+                _enums.DataType.FLOAT4E2M1,
                 _enums.DataType.FLOAT8E4M3FN,
                 _enums.DataType.FLOAT8E4M3FNUZ,
                 _enums.DataType.FLOAT8E5M2,
                 _enums.DataType.FLOAT8E5M2FNUZ,
+                _enums.DataType.INT16,
+                _enums.DataType.INT32,
                 _enums.DataType.INT4,
+                _enums.DataType.INT8,
+                _enums.DataType.UINT16,
                 _enums.DataType.UINT4,
-                _enums.DataType.FLOAT4E2M1,
+                _enums.DataType.UINT8,
             }, f"Unsupported dtype {dtype} for int32_data"
             array = np.array(self._proto.int32_data, dtype=_little_endian_dtype(np.int32))
             if dtype.bitwidth == 32:

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -415,12 +415,12 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
             }, f"Unsupported dtype {dtype} for int32_data"
             array = np.array(self._proto.int32_data, dtype=_little_endian_dtype(np.int32))
             if dtype.bitwidth == 32:
-                return array
+                return array.reshape(shape)
             if dtype.bitwidth == 16:
                 # Reinterpret the int32 as float16 or bfloat16
-                return array.astype(np.uint16).view(dtype.numpy())
+                return array.astype(np.uint16).view(dtype.numpy()).reshape(shape)
             if dtype.bitwidth == 8:
-                return array.astype(np.uint8).view(dtype.numpy())
+                return array.astype(np.uint8).view(dtype.numpy()).reshape(shape)
             if dtype.bitwidth == 4:
                 return _type_casting.unpack_4bitx2(array.astype(np.uint8), shape).view(
                     dtype.numpy()
@@ -432,7 +432,9 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
             assert dtype in {
                 _enums.DataType.INT64,
             }, f"Unsupported dtype {dtype} for int64_data"
-            return np.array(self._proto.int64_data, dtype=_little_endian_dtype(np.int64))
+            return np.array(
+                self._proto.int64_data, dtype=_little_endian_dtype(np.int64)
+            ).reshape(shape)
         if self._proto.uint64_data:
             assert dtype in {
                 _enums.DataType.UINT64,
@@ -440,8 +442,8 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
             }, f"Unsupported dtype {dtype} for uint64_data"
             array = np.array(self._proto.uint64_data, dtype=_little_endian_dtype(np.uint64))
             if dtype == _enums.DataType.UINT32:
-                return array.astype(np.uint32)
-            return array
+                return array.astype(np.uint32).reshape(shape)
+            return array.reshape(shape)
         if self._proto.float_data:
             assert dtype in {
                 _enums.DataType.FLOAT,
@@ -449,8 +451,8 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
             }, f"Unsupported dtype {dtype} for float_data"
             array = np.array(self._proto.float_data, dtype=_little_endian_dtype(np.float32))
             if dtype == _enums.DataType.COMPLEX64:
-                return array.view(np.complex64)
-            return array
+                return array.view(np.complex64).reshape(shape)
+            return array.reshape(shape)
         if self._proto.double_data:
             assert dtype in {
                 _enums.DataType.DOUBLE,
@@ -458,8 +460,8 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
             }, f"Unsupported dtype {dtype} for double_data"
             array = np.array(self._proto.double_data, dtype=_little_endian_dtype(np.float64))
             if dtype == _enums.DataType.COMPLEX128:
-                return array.view(np.complex128)
-            return array
+                return array.view(np.complex128).reshape(shape)
+            return array.reshape(shape)
 
         # Empty tensor
         if not shape:

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -463,11 +463,7 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
                 return array.view(np.complex128).reshape(shape)
             return array.reshape(shape)
 
-        # Empty tensor
-        if not shape:
-            # When dims not precent and there is no data, we return an empty array
-            return np.array([], dtype=dtype.numpy())
-        # Otherwise we return a size 0 array with the correct shape
+        # Empty tensor. We return a size 0 array with the correct shape
         return np.zeros(shape, dtype=dtype.numpy())
 
     def tobytes(self) -> bytes:

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -393,7 +393,7 @@ class TensorProtoTensorTest(unittest.TestCase):
             ir.DataType.BFLOAT16,
         }:
             # There is a bug in ml_dtypes that causes equality checks to fail for these dtypes
-            # See
+            # See https://github.com/jax-ml/ml_dtypes/issues/301
             self.assertEqual(roundtrip_array.shape, original_array.shape)
             self.assertEqual(roundtrip_array.dtype, original_array.dtype)
             self.assertEqual(roundtrip_array.tobytes(), original_array.tobytes())


### PR DESCRIPTION
4bit tensor unpacking to numpy array was buggy before this fix. I updated the logic to make sure we correctly handle the bytes when converting to numpy.

Added unit tests for all numeric dtypes.