### PR TITLE
Update pyproject.toml to require setuptools>=77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=70"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Support for project.license-files and SPDX license expressions in project.license (PEP 639) were introduced in version 77.0.0.