### PR TITLE
Default attribute type to INTS to avoid breaking BC

### DIFF
--- a/src/onnx_ir/_convenience/__init__.py
+++ b/src/onnx_ir/_convenience/__init__.py
@@ -256,8 +256,10 @@ def convert_attributes(
         )]), Attr('type_proto', TYPE_PROTO, Tensor(FLOAT)), Attr('type_protos', TYPE_PROTOS, [Tensor(FLOAT), Tensor(FLOAT)])]
 
     .. important::
-        An empty sequence should be created with an
-        explicit type by initializing an Attr object with an attribute type.
+        An empty sequence should be created with an explicit type by initializing
+        an Attr object with an attribute type to avoid type ambiguity. For example::
+
+            ir.Attr("empty", [], type=ir.AttributeType.INTS)
 
     Args:
         attrs: A dictionary of {<attribute name>: <python objects>} to convert.


### PR DESCRIPTION
Default attribute type to INTS in convenience functions because otherwise the behavior would be BC breaking.