### PR TITLE
Support string tensors in DeduplicateInitializersPass and call_onnx_api

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -837,6 +837,16 @@ class StringTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=to
         return self._shape
 
     @property
+    def size(self) -> int:
+        """The number of elements in the tensor."""
+        return sum((len(string) for string in self.string_data()))
+
+    @property
+    def nbytes(self) -> int:
+        """The number of bytes in the tensor."""
+        return self.size
+
+    @property
     def raw(self) -> Sequence[bytes] | npt.NDArray[np.bytes_]:
         """Backing data of the tensor. Immutable."""
         return self._raw  # type: ignore[return-value]

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -837,14 +837,9 @@ class StringTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=to
         return self._shape
 
     @property
-    def size(self) -> int:
-        """The number of elements in the tensor."""
-        return sum(len(string) for string in self.string_data())
-
-    @property
     def nbytes(self) -> int:
         """The number of bytes in the tensor."""
-        return self.size
+        return sum(len(string) for string in self.string_data())
 
     @property
     def raw(self) -> Sequence[bytes] | npt.NDArray[np.bytes_]:

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -839,7 +839,7 @@ class StringTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=to
     @property
     def size(self) -> int:
         """The number of elements in the tensor."""
-        return sum((len(string) for string in self.string_data()))
+        return sum(len(string) for string in self.string_data())
 
     @property
     def nbytes(self) -> int:

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -2506,5 +2506,6 @@ class StringTensorTest(unittest.TestCase):
         tensor = _core.StringTensor(data)
         self.assertEqual(tensor.nbytes, 3)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -2485,5 +2485,26 @@ class PackedTensorTest(unittest.TestCase):
         self.assertEqual(result.sum(), 10)  # 1+2+3+4 = 10
 
 
+class StringTensorTest(unittest.TestCase):
+    def test_nbytes(self):
+        data = np.array([b"A", b"BC", b"D"])
+        tensor = _core.StringTensor(data)
+        self.assertEqual(tensor.nbytes, 4)
+
+    def test_nbytes_2d(self):
+        data = np.array([[b"A", b"BC", b"D"], [b"EFG", b"H", b"I"]])
+        tensor = _core.StringTensor(data)
+        self.assertEqual(tensor.nbytes, 9)
+
+    def test_nbytes_empty(self):
+        data = np.array([])
+        tensor = _core.StringTensor(data)
+        self.assertEqual(tensor.nbytes, 0)
+
+    def test_nbytes_single(self):
+        data = np.array([b"ABC"])
+        tensor = _core.StringTensor(data)
+        self.assertEqual(tensor.nbytes, 3)
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/onnx_ir/_enums.py
+++ b/src/onnx_ir/_enums.py
@@ -77,7 +77,7 @@ class DataType(enum.IntEnum):
         if dtype in _NP_TYPE_TO_DATA_TYPE:
             return cls(_NP_TYPE_TO_DATA_TYPE[dtype])
 
-        if np.issubdtype(dtype, np.str_):
+        if np.issubdtype(dtype, np.str_) or np.issubdtype(dtype, np.bytes_):
             return DataType.STRING
 
         # Special cases for handling custom dtypes defined in ONNX (as of onnx 1.18)

--- a/src/onnx_ir/_enums.py
+++ b/src/onnx_ir/_enums.py
@@ -215,6 +215,10 @@ class DataType(enum.IntEnum):
             DataType.FLOAT8E8M0,
         }
 
+    def is_string(self) -> bool:
+        """Returns True if the data type is a string type."""
+        return self == DataType.STRING
+
     def __repr__(self) -> str:
         return self.name
 

--- a/src/onnx_ir/passes/common/initializer_deduplication.py
+++ b/src/onnx_ir/passes/common/initializer_deduplication.py
@@ -47,8 +47,9 @@ def _should_skip_initializer(initializer: ir.Value, size_limit: int) -> bool:
     return False
 
 
-def _tobytes(val: ir.TensorProtocol):
+def _tobytes(val):
     """StringTensor does not support tobytes. Use 'string_data' instead.
+
     However, 'string_data' yields a list of bytes which cannot be hashed, i.e.,
     cannot be used to index into a dict. To generate keys for identifying
     tensors in initializer deduplication the following converts the list of
@@ -59,7 +60,6 @@ def _tobytes(val: ir.TensorProtocol):
     padding bytes so that each string occupies the same number of consecutive
     bytes in the flattened .tobytes representation.
     """
-
     if val.dtype.is_string():
         return np.array(val.string_data()).tobytes()
     return val.tobytes()

--- a/src/onnx_ir/passes/common/initializer_deduplication.py
+++ b/src/onnx_ir/passes/common/initializer_deduplication.py
@@ -44,14 +44,6 @@ def _should_skip_initializer(initializer: ir.Value, size_limit: int) -> bool:
             size_limit,
         )
         return True
-
-    if const_val.dtype == ir.DataType.STRING:
-        # Skip string initializers as they don't have a bytes representation
-        logger.warning(
-            "Skipped deduplication of string initializer '%s' (unsupported yet)",
-            initializer.name,
-        )
-        return True
     return False
 
 

--- a/src/onnx_ir/passes/common/initializer_deduplication_test.py
+++ b/src/onnx_ir/passes/common/initializer_deduplication_test.py
@@ -86,6 +86,19 @@ class DeduplicateInitializersTest(unittest.TestCase):
         self.assertEqual(len(new_model.graph.initializers), 2)
 
 
+    def test_string_initializers_with_same_bytes_but_different_grouping_not_deduplicated(self):
+        model = ir.from_onnx_text(
+            """
+            <ir_version: 10, opset_import: ["" : 17]>
+            agraph () => ()
+            <string[2] s1 = {"AB", "C"}, string[2] s2 = {"A", "BC"}> {
+            }
+            """
+        )
+        new_model = self.apply_pass(model)
+        self.assertEqual(len(new_model.graph.initializers), 2)
+
+
     def test_initializers_with_different_dtypes_not_deduplicated(self):
         model = ir.from_onnx_text(
             """

--- a/src/onnx_ir/passes/common/initializer_deduplication_test.py
+++ b/src/onnx_ir/passes/common/initializer_deduplication_test.py
@@ -85,7 +85,6 @@ class DeduplicateInitializersTest(unittest.TestCase):
         new_model = self.apply_pass(model)
         self.assertEqual(len(new_model.graph.initializers), 2)
 
-
     def test_string_initializers_with_same_bytes_but_different_grouping_not_deduplicated(self):
         model = ir.from_onnx_text(
             """
@@ -97,7 +96,6 @@ class DeduplicateInitializersTest(unittest.TestCase):
         )
         new_model = self.apply_pass(model)
         self.assertEqual(len(new_model.graph.initializers), 2)
-
 
     def test_initializers_with_different_dtypes_not_deduplicated(self):
         model = ir.from_onnx_text(


### PR DESCRIPTION
Getting the number of bytes in a string tensor needs special treatment as the STRING data type does not define a bitwidth but needs to be computed from flattening the strings into a sequence of bytes. See call_onnx_api querying .nbytes to temporarily remove large initializers.

String initializers need to be converted to bytes via the .string_data method instead of the .tobytes method in DeduplicateInitializersPass.

Also adds mapping of `np.bytes_` to `STRING` in `DataType.from_numpy`, which was probably just overlooked before, as object and `np.str_` (unicode strings) are already handled. This is related to https://github.com/microsoft/onnxscript/pull/2514