### PR TITLE
Support deserializing non-utf8 attributes in rare case

### DIFF
--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1146,6 +1146,8 @@ def _deserialize_attribute(
         try:
             return _core.AttrString(name, proto.s.decode("utf-8"), doc_string=doc_string)
         except UnicodeDecodeError:
+            # Even though onnx.ai/onnx/repo-docs/IR.html#attributes requires the attribute
+            # for strings to be utf-8 encoded bytes, custom ops may still store arbitrary data there
             logger.warning(
                 "Attribute '%s' contains invalid UTF-8 bytes. ONNX spec requires string attributes "
                 "to be UTF-8 encoded so the model is invalid. We will skip decoding the attribute and "
@@ -1803,6 +1805,8 @@ def _fill_in_value_for_attribute(
     elif type_ == _enums.AttributeType.STRING:
         # value: str
         if type(value) is bytes:
+            # Even though onnx.ai/onnx/repo-docs/IR.html#attributes requires the attribute
+            # for strings to be utf-8 encoded bytes, custom ops may still store arbitrary data there
             attribute_proto.s = value
         else:
             attribute_proto.s = value.encode("utf-8")

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1144,14 +1144,15 @@ def _deserialize_attribute(
         return _core.AttrFloat32(name, proto.f, doc_string=doc_string)
     if type_ == _enums.AttributeType.STRING:
         try:
-            string = proto.s.decode("utf-8")
+            return _core.AttrString(name, proto.s.decode("utf-8"), doc_string=doc_string)
         except UnicodeDecodeError:
-            string = proto.s
             logger.warning(
-                "Attribute '%s' contains invalid UTF-8 bytes.",
+                "Attribute '%s' contains invalid UTF-8 bytes. ONNX spec requires string attributes "
+                "to be UTF-8 encoded so the model is invalid. We will skip decoding the attribute and "
+                "use the bytes as attribute value",
                 name,
             )
-        return _core.AttrString(name, proto.s, doc_string=doc_string)
+
     if type_ == _enums.AttributeType.INTS:
         return _core.AttrInt64s(name, proto.ints, doc_string=doc_string)
     if type_ == _enums.AttributeType.FLOATS:

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1149,7 +1149,7 @@ def _deserialize_attribute(
             # Even though onnx.ai/onnx/repo-docs/IR.html#attributes requires the attribute
             # for strings to be utf-8 encoded bytes, custom ops may still store arbitrary data there
             logger.warning(
-                "Attribute '%s' contains invalid UTF-8 bytes. ONNX spec requires string attributes "
+                "Attribute %r contains invalid UTF-8 bytes. ONNX spec requires string attributes "
                 "to be UTF-8 encoded so the model is invalid. We will skip decoding the attribute and "
                 "use the bytes as attribute value",
                 name,
@@ -1807,6 +1807,12 @@ def _fill_in_value_for_attribute(
         if type(value) is bytes:
             # Even though onnx.ai/onnx/repo-docs/IR.html#attributes requires the attribute
             # for strings to be utf-8 encoded bytes, custom ops may still store arbitrary data there
+            logger.warning(
+                "Value in attribute %r should be a string but is instead bytes. ONNX "
+                "spec requires string attributes to be UTF-8 encoded so the model is invalid. "
+                "We will skip encoding the attribute and use the bytes as attribute value",
+                attribute_proto.name,
+            )
             attribute_proto.s = value
         else:
             attribute_proto.s = value.encode("utf-8")

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1152,6 +1152,7 @@ def _deserialize_attribute(
                 "use the bytes as attribute value",
                 name,
             )
+            return _core.Attr(name, type_, proto.s, doc_string=doc_string)
 
     if type_ == _enums.AttributeType.INTS:
         return _core.AttrInt64s(name, proto.ints, doc_string=doc_string)
@@ -1801,10 +1802,10 @@ def _fill_in_value_for_attribute(
         attribute_proto.type = onnx.AttributeProto.FLOAT
     elif type_ == _enums.AttributeType.STRING:
         # value: str
-        if type(value) is str:
-            attribute_proto.s = value.encode("utf-8")
-        else:
+        if type(value) is bytes:
             attribute_proto.s = value
+        else:
+            attribute_proto.s = value.encode("utf-8")
         attribute_proto.type = onnx.AttributeProto.STRING
     elif type_ == _enums.AttributeType.INTS:
         # value: Sequence[int]


### PR DESCRIPTION
Even though https://onnx.ai/onnx/repo-docs/IR.html#attributes requires the attribute for strings to be utf-8 encoded bytes, custom ops may still store arbitrary data there (see SentencepieceTokenizer in https://github.com/microsoft/onnxruntime-extensions).

This change allows the value to stay in bytes and be reserialized as-is.

Fix #182 