### PR TITLE
Require ml_dtypes>=0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["numpy", "onnx>=1.16", "typing_extensions>=4.10", "ml_dtypes"]
+dependencies = ["numpy", "onnx>=1.16", "typing_extensions>=4.10", "ml_dtypes>=0.5.0"]
 
 [project.urls]
 Homepage = "https://onnx.ai/ir-py"


### PR DESCRIPTION
Require ml_dtypes>=0.5.0 as a dependency because an older version of it does not have all the dtypes we need.