### PR TITLE
Change Attr `__str__` to use repr()

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -3484,7 +3484,7 @@ class Attr(
             return f"@{self.ref_attr_name}"
         if self.type == _enums.AttributeType.GRAPH:
             return textwrap.indent("\n" + str(self.value), " " * 4)
-        return str(self.value)
+        return repr(self.value)
 
     def __repr__(self) -> str:
         if self.is_ref():


### PR DESCRIPTION
When the attribute is string, for example, we want to display `"attr"` instead of `attr`.