### PR TITLE
Handle when the value type is not known when serializing shapes

### DIFF
--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1979,7 +1979,8 @@ def serialize_shape_into(type_proto: onnx.TypeProto, from_: _protocols.ShapeProt
         # We cannot write the shape because we do not know where to write it
         logger.warning(
             # TODO(justinchuby): Show more context about the value when move everything to an object
-            "The value type for shape %s is not known. Please set type for the value. Skipping serialization"
+            "The value type for shape %s is not known. Please set type for the value. Skipping serialization",
+            from_,
         )
         return
     tensor_type = getattr(type_proto, value_field)
@@ -1990,7 +1991,8 @@ def serialize_shape_into(type_proto: onnx.TypeProto, from_: _protocols.ShapeProt
         if value_field is None:
             logger.warning(
                 # TODO(justinchuby): Show more context about the value when move everything to an object
-                "The value type for shape %s is not known. Please set type for the value. Skipping serialization"
+                "The value type for shape %s is not known. Please set type for the value. Skipping serialization",
+                from_,
             )
             return
         tensor_type = getattr(type_proto, value_field)

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1972,26 +1972,27 @@ def serialize_type(type_protocol: _protocols.TypeProtocol) -> onnx.TypeProto:
     return type_proto
 
 
-def _get_value_field_from_type_proto_for_shape(
-    type_proto: onnx.TypeProto,
-) -> str:
-    value_field = type_proto.WhichOneof("value")
-    if value_field is None:
-        logger.warning(
-            "TypeProto does not have a value field set. Assuming a TypeProto.Tensor Type for shape serialization."
-        )
-        return "tensor_type"
-    return value_field
-
-
 @_capture_errors(lambda type_proto, from_: repr(from_))
 def serialize_shape_into(type_proto: onnx.TypeProto, from_: _protocols.ShapeProtocol) -> None:
-    value_field = _get_value_field_from_type_proto_for_shape(type_proto)
+    value_field = type_proto.WhichOneof("value")
+    if value_field is None:
+        # We cannot write the shape because we do not know where to write it
+        logger.warning(
+            # TODO(justinchuby): Show more context about the value when move everything to an object
+            "The value type for shape %s is not known. Please set type for the value. Skipping serialization"
+        )
+        return
     tensor_type = getattr(type_proto, value_field)
     while not isinstance(tensor_type.elem_type, int):
         # Find the leaf type that has the shape field
         type_proto = tensor_type.elem_type
-        value_field = _get_value_field_from_type_proto_for_shape(type_proto)
+        value_field = type_proto.WhichOneof("value")
+        if value_field is None:
+            logger.warning(
+                # TODO(justinchuby): Show more context about the value when move everything to an object
+                "The value type for shape %s is not known. Please set type for the value. Skipping serialization"
+            )
+            return
         tensor_type = getattr(type_proto, value_field)
     # When from is empty, we still need to set the shape field to an empty list by touching it
     tensor_type.shape.ClearField("dim")

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1972,14 +1972,26 @@ def serialize_type(type_protocol: _protocols.TypeProtocol) -> onnx.TypeProto:
     return type_proto
 
 
+def _get_value_field_from_type_proto_for_shape(
+    type_proto: onnx.TypeProto,
+) -> str:
+    value_field = type_proto.WhichOneof("value")
+    if value_field is None:
+        logger.warning(
+            "TypeProto does not have a value field set. Assuming a TypeProto.Tensor Type for shape serialization."
+        )
+        return "tensor_type"
+    return value_field
+
+
 @_capture_errors(lambda type_proto, from_: repr(from_))
 def serialize_shape_into(type_proto: onnx.TypeProto, from_: _protocols.ShapeProtocol) -> None:
-    value_field = type_proto.WhichOneof("value")
+    value_field = _get_value_field_from_type_proto_for_shape(type_proto)
     tensor_type = getattr(type_proto, value_field)
     while not isinstance(tensor_type.elem_type, int):
         # Find the leaf type that has the shape field
         type_proto = tensor_type.elem_type
-        value_field = type_proto.WhichOneof("value")
+        value_field = _get_value_field_from_type_proto_for_shape(type_proto)
         tensor_type = getattr(type_proto, value_field)
     # When from is empty, we still need to set the shape field to an empty list by touching it
     tensor_type.shape.ClearField("dim")

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -598,16 +598,14 @@ class SerializationTest(unittest.TestCase):
         self.assertEqual(deserialized_attr.type, attr.type)
         self.assertEqual(deserialized_attr.value, expected)
 
-    def test_serialize_shape_successful_when_value_type_not_known(self):
+    def test_serialize_shape_into_skips_writing_when_value_type_not_known(self):
         shape = ir.Shape((1, 2, 3))
         proto = onnx.TypeProto()
         self.assertIsNone(proto.WhichOneof("value"))
         serde.serialize_shape_into(proto, shape)
-        self.assertEqual(proto.WhichOneof("value"), "tensor_type")
+        self.assertIsNone(proto.WhichOneof("value"))
         deserialized = serde.deserialize_type_proto_for_shape(proto)
-        self.assertEqual(deserialized, shape)
-        self.assertIsNotNone(proto.tensor_type)
-        self.assertEqual(proto.tensor_type.elem_type, onnx.TensorProto.UNDEFINED)
+        self.assertIsNone(deserialized, shape)
 
 
 class QuantizationAnnotationTest(unittest.TestCase):

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -598,6 +598,16 @@ class SerializationTest(unittest.TestCase):
         self.assertEqual(deserialized_attr.type, attr.type)
         self.assertEqual(deserialized_attr.value, expected)
 
+    def test_serialize_shape_successful_when_value_type_not_known(self):
+        shape = ir.Shape((1, 2, 3))
+        proto = onnx.TypeProto()
+        self.assertIsNone(proto.WhichOneof("value"))
+        serde.serialize_shape_into(proto, shape)
+        self.assertEqual(proto.WhichOneof("value"), "tensor_type")
+        deserialized = serde.deserialize_type_proto_for_shape(proto)
+        self.assertEqual(deserialized, shape)
+        self.assertIsNotNone(proto.tensor_type)
+
 
 class QuantizationAnnotationTest(unittest.TestCase):
     """Test that quantization annotations are correctly serialized and deserialized."""

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -607,6 +607,7 @@ class SerializationTest(unittest.TestCase):
         deserialized = serde.deserialize_type_proto_for_shape(proto)
         self.assertEqual(deserialized, shape)
         self.assertIsNotNone(proto.tensor_type)
+        self.assertEqual(proto.tensor_type.elem_type, onnx.TensorProto.UNDEFINED)
 
 
 class QuantizationAnnotationTest(unittest.TestCase):


### PR DESCRIPTION
When the value type is not known, we don't know where to store the shape inside a type proto. This change will make the serializer skip serializing the shape instead of error out.

Fix https://github.com/onnx/ir-py/issues/202