### PR TITLE
Remove Python version classifiers from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,6 @@ license = "Apache-2.0"
 license-files = ["LICEN[CS]E*"]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
 ]
 dependencies = ["numpy", "onnx>=1.16", "typing_extensions>=4.10", "ml_dtypes>=0.5.0"]
 


### PR DESCRIPTION
Removed specific Python version classifiers from the project metadata as they are no longer recommended by pypi.