### PR TITLE
Escape `[...]` in text for rich display

### DIFF
--- a/src/onnx_ir/_display.py
+++ b/src/onnx_ir/_display.py
@@ -39,6 +39,11 @@ class PrettyPrintable:
             )
             return
 
+        import rich.markup
+
+        # Escape text to display `[...]` correctly
+        text = rich.markup.escape(text)
+
         if page:
             import rich.console
 


### PR DESCRIPTION
Previously `[...]` was not displayed correct due to how rich handles the text. This change fixes it by escaping the text.