### PR TITLE
improve speed of op_identitifer

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -2073,7 +2073,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
 
         The operator identifier is a tuple of the domain, op_type and overload.
         """
-        return self.domain, self.op_type, self.overload
+        return self._domain, self._op_type, self._overload
 
     def display(self, *, page: bool = False) -> None:
         """Pretty print the node.


### PR DESCRIPTION
Node.op_identifier is used a lot when a model is optimized.

Before the change:

<img width="800" height="399" alt="image" src="https://github.com/user-attachments/assets/dfd7fe65-17e7-4dab-a11a-4296595a5771" />

After the change:

<img width="931" height="302" alt="image" src="https://github.com/user-attachments/assets/f7a0d6cd-30d1-4ac0-af82-5bd9ed4c17c5" />
