### PR TITLE
Add allow_outer_scope_values option in Graph.clone()

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -3079,7 +3079,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
             pass
         yield from seen_graphs.keys()
 
-    def clone(self, no_outer_scope_values: bool = True) -> Graph:
+    def clone(self, allow_outer_scope_values: bool = False) -> Graph:
         """Create a deep copy of this graph in O(#nodes + #values) time.
 
         All nodes, values, and subgraphs are cloned. The cloned graph will have
@@ -3090,21 +3090,21 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
 
         .. versionadded:: 0.1.14
         .. versionadded:: 0.1.15
-            Added ``no_outer_scope_values`` argument.
+            Added ``allow_outer_scope_values`` argument.
 
         Args:
-            no_outer_scope_values: When False, values that are from outer scopes
+            allow_outer_scope_values: When True, values that are from outer scopes
                 (not defined in this graph) will not be cloned. Instead, the cloned
                 graph will reference the same outer scope values. This is useful
                 when cloning subgraphs that reference values from the outer graph.
-                When True (default), values from outer scopes will cause an error if they
+                When False (default), values from outer scopes will cause an error if they
                 are referenced in the cloned graph.
 
         Returns:
             A deep copy of this graph.
 
         Raises:
-            ValueError: If ``no_outer_scope_values`` is True and the graph
+            ValueError: If ``allow_outer_scope_values`` is False and the graph
                 references values from outer scopes.
         """
         from onnx_ir import _cloner
@@ -3114,7 +3114,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
             value_map={},
             metadata_props={},
             resolve_ref_attrs=False,
-            no_outer_scope_values=no_outer_scope_values,
+            allow_outer_scope_values=allow_outer_scope_values,
         )
         return cloner.clone_graph(self)
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -4007,7 +4007,7 @@ class GraphCloneTest(unittest.TestCase):
         self.assertIs(cloned_nodes[2].inputs[0], cloned_nodes[1].outputs[0])
         self.assertIs(cloned_nodes[2].inputs[1], cloned_nodes[0].outputs[0])
 
-    def test_clone_with_no_outer_scope_values_true_raises_error(self):
+    def test_clone_with_allow_outer_scope_values_false_raises_error(self):
         # Create main graph
         v0 = _core.Value(name="main_input")
 
@@ -4026,7 +4026,7 @@ class GraphCloneTest(unittest.TestCase):
             _ = subgraph.clone()
 
     def test_clone_with_allow_outer_scope_values(self):
-        """Test that outer scope values are preserved when no_outer_scope_values=False."""
+        """Test that outer scope values are preserved when allow_outer_scope_values=True."""
         # Create main graph
         v0 = _core.Value(name="main_input")
 
@@ -4039,8 +4039,8 @@ class GraphCloneTest(unittest.TestCase):
             name="subgraph",
         )
 
-        # Clone the subgraph with no_outer_scope_values=False
-        cloned_subgraph = subgraph.clone(no_outer_scope_values=False)
+        # Clone the subgraph with allow_outer_scope_values=True
+        cloned_subgraph = subgraph.clone(allow_outer_scope_values=True)
 
         # The outer scope value v0 should NOT be cloned, it should be preserved
         cloned_sub_node = cloned_subgraph[0]
@@ -4064,8 +4064,8 @@ class GraphCloneTest(unittest.TestCase):
             name="mixed_subgraph",
         )
 
-        # Clone with no_outer_scope_values=False
-        cloned_subgraph = subgraph.clone(no_outer_scope_values=False)
+        # Clone with allow_outer_scope_values=True
+        cloned_subgraph = subgraph.clone(allow_outer_scope_values=True)
 
         # Inner input should be cloned
         cloned_inner_input = cloned_subgraph.inputs[0]
@@ -4113,8 +4113,8 @@ class GraphCloneTest(unittest.TestCase):
             name="middle_subgraph",
         )
 
-        # Clone with no_outer_scope_values=False
-        cloned_middle = middle_subgraph.clone(no_outer_scope_values=False)
+        # Clone with allow_outer_scope_values=True
+        cloned_middle = middle_subgraph.clone(allow_outer_scope_values=True)
 
         # Condition should be cloned (it's an input)
         cloned_condition = cloned_middle.inputs[0]
@@ -4146,8 +4146,8 @@ class GraphCloneTest(unittest.TestCase):
             name="subgraph_with_init",
         )
 
-        # Clone with no_outer_scope_values=False
-        cloned_subgraph = subgraph.clone(no_outer_scope_values=False)
+        # Clone with allow_outer_scope_values=True
+        cloned_subgraph = subgraph.clone(allow_outer_scope_values=True)
 
         # Outer value should be preserved
         cloned_node = cloned_subgraph[0]
@@ -4161,7 +4161,7 @@ class GraphCloneTest(unittest.TestCase):
         self.assertIs(cloned_init.const_value, initializer_tensor)
 
     def test_clone_with_allow_outer_scope_values_outer_initializer(self):
-        """Test that initializers from outer graph are preserved when no_outer_scope_values=False."""
+        """Test that initializers from outer graph are preserved when allow_outer_scope_values=True."""
         # Create outer graph with initializer
         initializer_tensor = ir.tensor([1.0, 2.0, 3.0], name="outer_weights")
         outer_init = _core.Value(name="outer_weights", const_value=initializer_tensor)
@@ -4186,8 +4186,8 @@ class GraphCloneTest(unittest.TestCase):
             name="subgraph",
         )
 
-        # Clone the subgraph with no_outer_scope_values=False
-        cloned_subgraph = subgraph.clone(no_outer_scope_values=False)
+        # Clone the subgraph with allow_outer_scope_values=True
+        cloned_subgraph = subgraph.clone(allow_outer_scope_values=True)
 
         # The outer initializer should be preserved (not cloned)
         cloned_node = cloned_subgraph[0]
@@ -4213,8 +4213,8 @@ class GraphCloneTest(unittest.TestCase):
             name="chained_subgraph",
         )
 
-        # Clone with no_outer_scope_values=False
-        cloned_subgraph = subgraph.clone(no_outer_scope_values=False)
+        # Clone with allow_outer_scope_values=True
+        cloned_subgraph = subgraph.clone(allow_outer_scope_values=True)
 
         # Outer value should be preserved
         cloned_node1 = cloned_subgraph[0]


### PR DESCRIPTION
This pull request adds support for optionally preserving references to outer-scope values when cloning graphs in the ONNX IR, instead of always cloning them. This is particularly useful when cloning subgraphs that reference values defined in an outer graph. 

* Added a `allow_outer_scope_values` argument to the `Graph.clone()` method.
* Also preserve metadata.