### PR TITLE
Improve error messages from the inliner

### DIFF
--- a/src/onnx_ir/passes/common/inliner.py
+++ b/src/onnx_ir/passes/common/inliner.py
@@ -216,7 +216,7 @@ class InlinePass(ir.passes.InPlacePass):
         if len(node.inputs) > len(function.inputs):
             raise ValueError(
                 f"Input mismatch when inlining function '{_format_function_id(op_id)}': "
-                f"call site has {len(node.inputs)} inputs but function expects {len(function.inputs)} or less"
+                f"call site has {len(node.inputs)} inputs but function defines at most {len(function.inputs)} inputs"
             )
         value_map = {}
         for i, input in enumerate(node.inputs):


### PR DESCRIPTION
**Error message improvements:**

* Added a new helper function `_format_function_id` to consistently format operator identifiers as human-readable strings.
* Enhanced the opset mismatch error message in `_instantiate_call` to specify the function being inlined and provide more detailed context.
* Improved the error message for unsupported graph attribute parameters to include the function identifier.
* Clarified the input mismatch error message to specify the function name and the expected versus actual input counts.