### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/src/onnx_ir/__init__.py
+++ b/src/onnx_ir/__init__.py
@@ -174,4 +174,4 @@ def __set_module() -> None:
 
 
 __set_module()
-__version__ = "0.1.16"
+__version__ = "0.2.0"


### PR DESCRIPTION
Bumping to 0.2.0 because we will introduce sympy as a dependency.