### PR TITLE
Optional MetadataStore deep copy when cloning

### DIFF
--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -4139,6 +4139,19 @@ class GraphCloneTest(unittest.TestCase):
         self.assertTrue(cloned_graph.meta.is_valid("valid_key"))
         self.assertFalse(cloned_graph.meta.is_valid("invalid_key"))
 
+    @parameterized.parameterized.expand([(True,), (False,)])
+    def test_clone_graph_empty_meta_with_only_invalid_keys(self, deep_copy):
+        """Test cloning a graph with empty meta that has only invalid keys."""
+        v0 = _core.Value(name="input")
+        node = _core.Node("", "Identity", inputs=(v0,), num_outputs=1)
+        graph = _core.Graph(inputs=(v0,), outputs=(node.outputs[0],), nodes=(node,))
+        graph.meta.invalidate("invalid_key")
+
+        cloned_graph = graph.clone(deep_copy=deep_copy)
+
+        # Check validity
+        self.assertFalse(cloned_graph.meta.is_valid("invalid_key"))
+
     def test_clone_preserves_node_attributes(self):
         """Test that cloning preserves node attributes."""
         v0 = _core.Value(name="input")

--- a/src/onnx_ir/_metadata.py
+++ b/src/onnx_ir/_metadata.py
@@ -43,3 +43,6 @@ class MetadataStore(collections.UserDict):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r}, invalid_keys={self._invalid_keys!r})"
+
+    def __bool__(self) -> bool:
+        return bool(self.data) or bool(self._invalid_keys)


### PR DESCRIPTION
This PR introduces an optional deep copy when cloning for objects stored in the metadata store (addresses https://github.com/onnx/ir-py/issues/333).