### PR TITLE
Add tensor-centric accessors to GraphInitializers

### DIFF
--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -3288,6 +3288,58 @@ class GraphContainersTest(unittest.TestCase):
         self.assertTrue(initializers[0].is_initializer())
         self.assertEqual(initializers[0].graph, self.graph)
 
+    def test_tensors_yields_const_values(self):
+        self.graph.initializers.add(self.value3)
+        other = _core.Value(name="initializer2", const_value=ir.tensor([4, 5]))
+        self.graph.initializers.add(other)
+
+        tensors = list(self.graph.initializers.tensors())
+        self.assertEqual(len(tensors), 2)
+        self.assertIs(tensors[0], self.value3.const_value)
+        self.assertIs(tensors[1], other.const_value)
+
+    def test_tensor_items_yields_name_tensor_pairs(self):
+        self.graph.initializers.add(self.value3)
+
+        items = list(self.graph.initializers.tensor_items())
+        self.assertEqual(len(items), 1)
+        name, tensor = items[0]
+        self.assertEqual(name, "initializer1")
+        self.assertIs(tensor, self.value3.const_value)
+
+    def test_tensors_raises_when_const_value_missing(self):
+        pending = _core.Value(name="pending")  # no const_value
+        self.graph.initializers.add(pending)
+
+        with self.assertRaisesRegex(ValueError, "no const_value"):
+            list(self.graph.initializers.tensors())
+        with self.assertRaisesRegex(ValueError, "no const_value"):
+            list(self.graph.initializers.tensor_items())
+
+    def test_get_tensor_returns_const_value(self):
+        self.graph.initializers.add(self.value3)
+        self.assertIs(
+            self.graph.initializers.get_tensor("initializer1"),
+            self.value3.const_value,
+        )
+
+    def test_get_tensor_returns_default_when_missing(self):
+        self.assertIsNone(self.graph.initializers.get_tensor("non_existent"))
+        sentinel = object()
+        self.assertIs(
+            self.graph.initializers.get_tensor("non_existent", sentinel),
+            sentinel,
+        )
+
+    def test_get_tensor_returns_default_when_const_value_missing(self):
+        pending = _core.Value(name="pending")  # no const_value
+        self.graph.initializers.add(pending)
+        sentinel = object()
+        # get_tensor returns default for missing const_value (unlike
+        # tensors() / tensor_items() which raise).
+        self.assertIs(self.graph.initializers.get_tensor("pending", sentinel), sentinel)
+        self.assertIsNone(self.graph.initializers.get_tensor("pending"))
+
     def test_contains_initializer(self):
         self.graph.initializers["initializer1"] = self.value3
         self.assertIn("initializer1", self.graph.initializers)

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -305,10 +305,12 @@ class GraphInitializers(collections.UserDict[str, "_core.Value"]):
         Mirrors :meth:`dict.values` but returns each initializer's
         ``const_value`` instead of its wrapping :class:`Value`.
 
+        .. versionadded:: 0.3.0
+
         Raises:
             ValueError: If any initializer has ``const_value=None``.
                 An initializer without a backing tensor is almost always
-                a graph-construction bug — surfacing it loudly here is
+                a graph-construction bug -- surfacing it loudly here is
                 preferable to silently yielding ``None``.
         """
         for value in self.data.values():
@@ -322,6 +324,8 @@ class GraphInitializers(collections.UserDict[str, "_core.Value"]):
 
     def tensor_items(self) -> Iterator[tuple[str, _protocols.TensorProtocol]]:
         """Iterate over ``(name, tensor)`` pairs. Mirrors :meth:`dict.items`.
+
+        .. versionadded:: 0.3.0
 
         Raises:
             ValueError: If any initializer has ``const_value=None``
@@ -344,6 +348,8 @@ class GraphInitializers(collections.UserDict[str, "_core.Value"]):
         Returns ``default`` both when ``name`` is not an initializer and
         when it is but its ``const_value`` is ``None``. Mirrors
         :meth:`dict.get` but at the tensor level.
+
+        .. versionadded:: 0.3.0
         """
         value = self.data.get(name)
         if value is None or value.const_value is None:

--- a/src/onnx_ir/_graph_containers.py
+++ b/src/onnx_ir/_graph_containers.py
@@ -13,7 +13,7 @@ __all__ = [
 
 import collections
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from typing import SupportsIndex, TypeVar
 
 import onnx_ir
@@ -288,6 +288,67 @@ class GraphInitializers(collections.UserDict[str, "_core.Value"]):
     def add(self, value: _core.Value) -> None:
         """Add an initializer to the graph."""
         self[value.name] = value  # type: ignore[index]
+
+    # ------------------------------------------------------------------
+    # Tensor-centric convenience accessors
+    #
+    # ``GraphInitializers`` is a ``dict[str, Value]`` for backward
+    # compatibility, but in practice almost every caller actually wants
+    # the backing ``Tensor`` (``value.const_value``). These methods let
+    # callers ask for tensors directly without breaking the underlying
+    # ``Value``-typed API.
+    # ------------------------------------------------------------------
+
+    def tensors(self) -> Iterator[_protocols.TensorProtocol]:
+        """Iterate over the backing tensors of all initializers.
+
+        Mirrors :meth:`dict.values` but returns each initializer's
+        ``const_value`` instead of its wrapping :class:`Value`.
+
+        Raises:
+            ValueError: If any initializer has ``const_value=None``.
+                An initializer without a backing tensor is almost always
+                a graph-construction bug — surfacing it loudly here is
+                preferable to silently yielding ``None``.
+        """
+        for value in self.data.values():
+            if value.const_value is None:
+                raise ValueError(
+                    f"Initializer {value.name!r} has no const_value. "
+                    "Set value.const_value before iterating, or iterate "
+                    "over .values() if you need to handle pending initializers."
+                )
+            yield value.const_value
+
+    def tensor_items(self) -> Iterator[tuple[str, _protocols.TensorProtocol]]:
+        """Iterate over ``(name, tensor)`` pairs. Mirrors :meth:`dict.items`.
+
+        Raises:
+            ValueError: If any initializer has ``const_value=None``
+                (see :meth:`tensors`).
+        """
+        for name, value in self.data.items():
+            if value.const_value is None:
+                raise ValueError(
+                    f"Initializer {name!r} has no const_value. "
+                    "Set value.const_value before iterating, or iterate "
+                    "over .items() if you need to handle pending initializers."
+                )
+            yield name, value.const_value
+
+    def get_tensor(
+        self, name: str, default: _protocols.TensorProtocol | None = None
+    ) -> _protocols.TensorProtocol | None:
+        """Return the backing tensor for ``name``, or ``default``.
+
+        Returns ``default`` both when ``name`` is not an initializer and
+        when it is but its ``const_value`` is ``None``. Mirrors
+        :meth:`dict.get` but at the tensor level.
+        """
+        value = self.data.get(name)
+        if value is None or value.const_value is None:
+            return default
+        return value.const_value
 
 
 class Attributes(collections.UserDict[str, "_core.Attr"]):


### PR DESCRIPTION
## Motivation

`graph.initializers` is a `dict[str, Value]` for backward compatibility, but the value almost every caller actually wants is the backing `Tensor` (`value.const_value`). Reading initializer tensors today requires either

```python
for v in g.initializers.values():
    t = v.const_value     # might also be None
    ...
```

or, per name, `g.initializers[name].const_value` — three layers of indirection for a very common operation. Writing isn't much fun either: you have to construct a `Value(name=..., shape=..., type=..., const_value=tensor)` manually before calling `.add()`.

## What's in this PR (additive only)

Three new methods on `GraphInitializers`:

| method | mirrors | returns |
|---|---|---|
| `tensors()` | `dict.values()` | `Iterator[Tensor]` |
| `tensor_items()` | `dict.items()` | `Iterator[(str, Tensor)]` |
| `get_tensor(name, default=None)` | `dict.get` | `Tensor \| None` |

Typical use:

```python
# Before
for v in g.initializers.values():
    arr = v.const_value.numpy()
    ...

# After
for name, tensor in g.initializers.tensor_items():
    arr = tensor.numpy()
    ...
```

## Design decisions worth confirming

1. **`tensors()` / `tensor_items()` raise on missing `const_value`.** An initializer without a backing tensor is almost always a graph-construction bug — the whole point of an initializer is to ship a tensor. Surfacing that loudly here matches `Mapping[str, Tensor]` semantics. Callers who legitimately need to handle pending values can keep using `.values()` / `.items()` directly.

2. **`get_tensor` is more lenient.** Returns `default` both when the key is missing and when `const_value` is `None`. This matches the spirit of `dict.get` (no exceptions).

3. **No new write API in this PR.** I considered adding `set_tensor(name, tensor)` to remove the verbose `Value(...)` construction for the create-or-update case, and a `as_tensors` read-only `Mapping[str, Tensor]` view that turns the whole `Mapping[str, Tensor]` model into a first-class thing. Both could be follow-ups — I'd like to see if the three read accessors here cover the bulk of the ergonomics first.

## Compatibility

Strictly additive. `graph.initializers[name]` still returns `Value`. `.values()`, `.items()`, `.keys()`, `__iter__`, `__contains__`, `__len__`, `pop`, `update`, `add` — all unchanged. Existing tests (3157 unit tests under `src/` + `tests/`) all pass.

## Tests

`GraphContainersTest` gains six new cases covering happy path, name+tensor pairs, default handling, and the missing-`const_value` raise behaviour.