### PR TITLE
Use new GraphInitializers tensor APIs to simplify codebase

### DIFF
--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -60,7 +60,7 @@ class IOFunctionsTest(unittest.TestCase):
         self.assertEqual(len(loaded_model.graph.initializers), 1)
         self.assertEqual(len(loaded_model.graph), 2)
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["initializer_0"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("initializer_0").numpy(),
             np.array([0.0]),
         )
         np.testing.assert_array_equal(
@@ -72,7 +72,7 @@ class IOFunctionsTest(unittest.TestCase):
 
     def test_save_with_external_data_does_not_modify_model(self):
         model = _create_simple_model_with_initializers()
-        self.assertIsInstance(model.graph.initializers["initializer_0"].const_value, ir.Tensor)
+        self.assertIsInstance(model.graph.initializers.get_tensor("initializer_0"), ir.Tensor)
         # There may be clean up errors on Windows, so we ignore them
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")
@@ -84,7 +84,7 @@ class IOFunctionsTest(unittest.TestCase):
             loaded_model = _io.load(path)
 
             # The loaded model contains external data
-            initializer_tensor = loaded_model.graph.initializers["initializer_0"].const_value
+            initializer_tensor = loaded_model.graph.initializers.get_tensor("initializer_0")
             self.assertIsInstance(initializer_tensor, ir.ExternalTensor)
             # The attribute is not externalized
             const_attr_tensor = loaded_model.graph.node(1).attributes["value"].as_tensor()
@@ -94,7 +94,7 @@ class IOFunctionsTest(unittest.TestCase):
 
         # The original model is not changed and can be accessed even if the
         # external data file is deleted
-        initializer_tensor = model.graph.initializers["initializer_0"].const_value
+        initializer_tensor = model.graph.initializers.get_tensor("initializer_0")
         self.assertIsInstance(initializer_tensor, ir.Tensor)
         const_attr_tensor = model.graph.node(1).attributes["value"].as_tensor()
         self.assertIsInstance(const_attr_tensor, ir.Tensor)
@@ -111,7 +111,7 @@ class IOFunctionsTest(unittest.TestCase):
 
     def test_save_with_external_data_invalidates_obsolete_external_tensors(self):
         model = _create_simple_model_with_initializers()
-        self.assertIsInstance(model.graph.initializers["initializer_0"].const_value, ir.Tensor)
+        self.assertIsInstance(model.graph.initializers.get_tensor("initializer_0"), ir.Tensor)
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")
             external_data_file = "model.data"
@@ -126,7 +126,7 @@ class IOFunctionsTest(unittest.TestCase):
             _io.save(
                 loaded_model, path, external_data=external_data_file, size_threshold_bytes=0
             )
-            initializer_0_tensor = loaded_model.graph.initializers["initializer_0"].const_value
+            initializer_0_tensor = loaded_model.graph.initializers.get_tensor("initializer_0")
             self.assertIsInstance(initializer_0_tensor, ir.ExternalTensor)
             self.assertFalse(initializer_0_tensor.valid())
             with self.assertRaisesRegex(ValueError, "is invalidated"):

--- a/src/onnx_ir/_safetensors/_safetensors_test.py
+++ b/src/onnx_ir/_safetensors/_safetensors_test.py
@@ -130,9 +130,9 @@ class SaveSafetensorsTest(unittest.TestCase):
         ir.save_safetensors(model, path, size_threshold_bytes=0)
 
         # Check that original model still has in-memory tensors
-        for value in model.graph.initializers.values():
-            self.assertIsInstance(value.const_value, ir.Tensor)
-            self.assertNotIsInstance(value.const_value, ir.ExternalTensor)
+        for tensor in model.graph.initializers.tensors():
+            self.assertIsInstance(tensor, ir.Tensor)
+            self.assertNotIsInstance(tensor, ir.ExternalTensor)
 
     def test_save_safetensors_loads_correctly(self):
         """Test that a model saved with safetensors can be loaded correctly."""
@@ -146,11 +146,11 @@ class SaveSafetensorsTest(unittest.TestCase):
 
         # Check that the loaded model has external tensors
         self.assertEqual(len(loaded_model.graph.initializers), 3)
-        for name, value in loaded_model.graph.initializers.items():
-            self.assertIsInstance(value.const_value, ir.ExternalTensor)
+        for name, tensor in loaded_model.graph.initializers.tensor_items():
+            self.assertIsInstance(tensor, ir.ExternalTensor)
             # Check that the data is correct
-            original_tensor = model.graph.initializers[name].const_value
-            np.testing.assert_array_equal(value.const_value.numpy(), original_tensor.numpy())
+            original_tensor = model.graph.initializers.get_tensor(name)
+            np.testing.assert_array_equal(tensor.numpy(), original_tensor.numpy())
 
     def test_save_safetensors_size_threshold(self):
         """Test that size_threshold_bytes correctly filters tensors."""
@@ -164,8 +164,8 @@ class SaveSafetensorsTest(unittest.TestCase):
         loaded_model = ir.load(path)
 
         # All tensors should still be in memory (not external)
-        for value in loaded_model.graph.initializers.values():
-            self.assertNotIsInstance(value.const_value, ir.ExternalTensor)
+        for tensor in loaded_model.graph.initializers.tensors():
+            self.assertNotIsInstance(tensor, ir.ExternalTensor)
 
     def test_save_safetensors_with_sharding(self):
         """Test that sharding works correctly."""
@@ -284,15 +284,15 @@ class SaveSafetensorsTest(unittest.TestCase):
 
         # Check that the data is correct for all types
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["int32_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("int32_tensor").numpy(),
             np.array([1, 2, 3], dtype=np.int32),
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["float16_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("float16_tensor").numpy(),
             np.array([1.0, 2.0, 3.0], dtype=np.float16),
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["bool_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("bool_tensor").numpy(),
             np.array([True, False, True], dtype=bool),
         )
 
@@ -354,50 +354,50 @@ class SaveSafetensorsTest(unittest.TestCase):
             "uint2_tensor",
         ]:
             self.assertIsInstance(
-                loaded_model.graph.initializers[tensor_name].const_value, ir.ExternalTensor
+                loaded_model.graph.initializers.get_tensor(tensor_name), ir.ExternalTensor
             )
 
         # Check that the raw data is preserved
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["int4_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("int4_tensor").numpy(),
             int4_data,
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["uint4_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("uint4_tensor").numpy(),
             uint4_data,
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["float4_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("float4_tensor").numpy(),
             float4_data,
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["int2_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("int2_tensor").numpy(),
             int2_data,
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["uint2_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("uint2_tensor").numpy(),
             uint2_data,
         )
 
         # Check that the dtype is preserved
         self.assertEqual(
-            loaded_model.graph.initializers["int4_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("int4_tensor").dtype,
             ir.DataType.INT4,
         )
         self.assertEqual(
-            loaded_model.graph.initializers["uint4_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("uint4_tensor").dtype,
             ir.DataType.UINT4,
         )
         self.assertEqual(
-            loaded_model.graph.initializers["float4_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("float4_tensor").dtype,
             ir.DataType.FLOAT4E2M1,
         )
         self.assertEqual(
-            loaded_model.graph.initializers["int2_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("int2_tensor").dtype,
             ir.DataType.INT2,
         )
         self.assertEqual(
-            loaded_model.graph.initializers["uint2_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("uint2_tensor").dtype,
             ir.DataType.UINT2,
         )
 
@@ -463,43 +463,43 @@ class SaveSafetensorsTest(unittest.TestCase):
             "f8_e5m2fnuz_tensor",
         ]:
             self.assertIsInstance(
-                loaded_model.graph.initializers[tensor_name].const_value,
+                loaded_model.graph.initializers.get_tensor(tensor_name),
                 ir.ExternalTensor,
             )
 
         # Check that the raw data is preserved for each type
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["f8_e5m2_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("f8_e5m2_tensor").numpy(),
             f8_e5m2_data,
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["f8_e4m3fn_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("f8_e4m3fn_tensor").numpy(),
             f8_e4m3fn_data,
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["f8_e4m3fnuz_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("f8_e4m3fnuz_tensor").numpy(),
             f8_e4m3fnuz_data,
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["f8_e5m2fnuz_tensor"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("f8_e5m2fnuz_tensor").numpy(),
             f8_e5m2fnuz_data,
         )
 
         # Check that the dtype is preserved for each type
         self.assertEqual(
-            loaded_model.graph.initializers["f8_e5m2_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("f8_e5m2_tensor").dtype,
             ir.DataType.FLOAT8E5M2,
         )
         self.assertEqual(
-            loaded_model.graph.initializers["f8_e4m3fn_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("f8_e4m3fn_tensor").dtype,
             ir.DataType.FLOAT8E4M3FN,
         )
         self.assertEqual(
-            loaded_model.graph.initializers["f8_e4m3fnuz_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("f8_e4m3fnuz_tensor").dtype,
             ir.DataType.FLOAT8E4M3FNUZ,
         )
         self.assertEqual(
-            loaded_model.graph.initializers["f8_e5m2fnuz_tensor"].const_value.dtype,
+            loaded_model.graph.initializers.get_tensor("f8_e5m2fnuz_tensor").dtype,
             ir.DataType.FLOAT8E5M2FNUZ,
         )
 
@@ -600,30 +600,30 @@ class SaveSafetensorsTest(unittest.TestCase):
 
         # Check main graph initializers
         self.assertIsInstance(
-            loaded_model.graph.initializers["main_init"].const_value, ir.ExternalTensor
+            loaded_model.graph.initializers.get_tensor("main_init"), ir.ExternalTensor
         )
         np.testing.assert_array_equal(
-            loaded_model.graph.initializers["main_init"].const_value.numpy(),
+            loaded_model.graph.initializers.get_tensor("main_init").numpy(),
             main_tensor.numpy(),
         )
 
         # Check then branch initializers
         then_branch = loaded_model.graph.node(0).attributes["then_branch"].as_graph()
         self.assertIsInstance(
-            then_branch.initializers["then_init"].const_value, ir.ExternalTensor
+            then_branch.initializers.get_tensor("then_init"), ir.ExternalTensor
         )
         np.testing.assert_array_equal(
-            then_branch.initializers["then_init"].const_value.numpy(),
+            then_branch.initializers.get_tensor("then_init").numpy(),
             then_tensor.numpy(),
         )
 
         # Check else branch initializers
         else_branch = loaded_model.graph.node(0).attributes["else_branch"].as_graph()
         self.assertIsInstance(
-            else_branch.initializers["else_init"].const_value, ir.ExternalTensor
+            else_branch.initializers.get_tensor("else_init"), ir.ExternalTensor
         )
         np.testing.assert_array_equal(
-            else_branch.initializers["else_init"].const_value.numpy(),
+            else_branch.initializers.get_tensor("else_init").numpy(),
             else_tensor.numpy(),
         )
 

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -53,7 +53,7 @@ class ExternalDataTest(unittest.TestCase):
         expected_dir = "something_else"
         external_data.set_base_dir(model.graph, expected_dir)
 
-        initializer_tensor = model.graph.initializers["test_tensor"].const_value
+        initializer_tensor = model.graph.initializers.get_tensor("test_tensor")
         assert isinstance(initializer_tensor, ir.ExternalTensor)
         self.assertEqual(initializer_tensor.base_dir, expected_dir)
         attr_tensor = model.graph.node(0).attributes["value"].value
@@ -319,23 +319,23 @@ class OffloadExternalTensorTest(unittest.TestCase):
         model_custom_tensor = self.model_with_custom_tensor_class
         model.graph.initializers["tensor_same_file"] = ir.Value(
             name="tensor_same_file",
-            const_value=model_same_path.graph.initializers["tensor_same_file"].const_value,
+            const_value=model_same_path.graph.initializers.get_tensor("tensor_same_file"),
         )
         model.graph.initializers["tensor_ext1_1"] = ir.Value(
             name="tensor_ext1_1",
-            const_value=model_diff_path.graph.initializers["tensor_ext1_1"].const_value,
+            const_value=model_diff_path.graph.initializers.get_tensor("tensor_ext1_1"),
         )
         model.graph.initializers["tensor_ext1_2"] = ir.Value(
             name="tensor_ext1_2",
-            const_value=model_diff_path.graph.initializers["tensor_ext1_2"].const_value,
+            const_value=model_diff_path.graph.initializers.get_tensor("tensor_ext1_2"),
         )
         model.graph.initializers["tensor_ext2_1"] = ir.Value(
             name="tensor_ext2_1",
-            const_value=model_diff_path.graph.initializers["tensor_ext2_1"].const_value,
+            const_value=model_diff_path.graph.initializers.get_tensor("tensor_ext2_1"),
         )
         model.graph.initializers["custom_tensor"] = ir.Value(
             name="custom_tensor",
-            const_value=model_custom_tensor.graph.initializers["custom_tensor"].const_value,
+            const_value=model_custom_tensor.graph.initializers.get_tensor("custom_tensor"),
         )
         return model
 
@@ -343,8 +343,8 @@ class OffloadExternalTensorTest(unittest.TestCase):
         model_with_external_data = external_data.unload_from_model(
             self.model, self.base_path, self.external_data_name
         )
-        external_tensor = model_with_external_data.graph.initializers["tensor1"].const_value
-        external_tensor2 = model_with_external_data.graph.initializers["tensor2"].const_value
+        external_tensor = model_with_external_data.graph.initializers.get_tensor("tensor1")
+        external_tensor2 = model_with_external_data.graph.initializers.get_tensor("tensor2")
 
         self.assertEqual(external_tensor.numpy().tobytes(), self.data.tobytes())
         self.assertEqual(external_tensor2.numpy().tobytes(), self.data_float16.tobytes())
@@ -358,11 +358,11 @@ class OffloadExternalTensorTest(unittest.TestCase):
             self.base_path,
             self.external_data_name,
         )
-        external_tensor = model_with_external_data.graph.initializers["tensor1"].const_value
-        external_tensor2 = model_with_external_data.graph.initializers["tensor2"].const_value
-        external_tensor3 = model_with_external_data.graph.initializers[
+        external_tensor = model_with_external_data.graph.initializers.get_tensor("tensor1")
+        external_tensor2 = model_with_external_data.graph.initializers.get_tensor("tensor2")
+        external_tensor3 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_same_file"
-        ].const_value
+        )
 
         self.assertEqual(external_tensor.numpy().tobytes(), self.data.tobytes())
         self.assertEqual(external_tensor2.numpy().tobytes(), self.data_float16.tobytes())
@@ -378,17 +378,17 @@ class OffloadExternalTensorTest(unittest.TestCase):
             self.base_path,
             self.external_data_name,
         )
-        external_tensor = model_with_external_data.graph.initializers["tensor1"].const_value
-        external_tensor2 = model_with_external_data.graph.initializers["tensor2"].const_value
-        external_tensor3 = model_with_external_data.graph.initializers[
+        external_tensor = model_with_external_data.graph.initializers.get_tensor("tensor1")
+        external_tensor2 = model_with_external_data.graph.initializers.get_tensor("tensor2")
+        external_tensor3 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_ext1_1"
-        ].const_value
-        external_tensor4 = model_with_external_data.graph.initializers[
+        )
+        external_tensor4 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_ext1_2"
-        ].const_value
-        external_tensor5 = model_with_external_data.graph.initializers[
+        )
+        external_tensor5 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_ext2_1"
-        ].const_value
+        )
 
         self.assertEqual(external_tensor.numpy().tobytes(), self.data.tobytes())
         self.assertEqual(external_tensor2.numpy().tobytes(), self.data_float16.tobytes())
@@ -408,11 +408,11 @@ class OffloadExternalTensorTest(unittest.TestCase):
             self.base_path,
             self.external_data_name,
         )
-        external_tensor = model_with_external_data.graph.initializers["tensor1"].const_value
-        external_tensor2 = model_with_external_data.graph.initializers["tensor2"].const_value
-        external_tensor3 = model_with_external_data.graph.initializers[
+        external_tensor = model_with_external_data.graph.initializers.get_tensor("tensor1")
+        external_tensor2 = model_with_external_data.graph.initializers.get_tensor("tensor2")
+        external_tensor3 = model_with_external_data.graph.initializers.get_tensor(
             "custom_tensor"
-        ].const_value
+        )
 
         self.assertEqual(external_tensor.numpy().tobytes(), self.data.tobytes())
         self.assertEqual(external_tensor2.numpy().tobytes(), self.data_float16.tobytes())
@@ -426,23 +426,23 @@ class OffloadExternalTensorTest(unittest.TestCase):
         model_with_external_data = external_data.unload_from_model(
             self.model_with_mixed_external_data, self.base_path, self.external_data_name
         )
-        external_tensor = model_with_external_data.graph.initializers["tensor1"].const_value
-        external_tensor2 = model_with_external_data.graph.initializers["tensor2"].const_value
-        external_tensor3 = model_with_external_data.graph.initializers[
+        external_tensor = model_with_external_data.graph.initializers.get_tensor("tensor1")
+        external_tensor2 = model_with_external_data.graph.initializers.get_tensor("tensor2")
+        external_tensor3 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_same_file"
-        ].const_value
-        external_tensor4 = model_with_external_data.graph.initializers[
+        )
+        external_tensor4 = model_with_external_data.graph.initializers.get_tensor(
             "custom_tensor"
-        ].const_value
-        external_tensor5 = model_with_external_data.graph.initializers[
+        )
+        external_tensor5 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_ext1_1"
-        ].const_value
-        external_tensor6 = model_with_external_data.graph.initializers[
+        )
+        external_tensor6 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_ext1_2"
-        ].const_value
-        external_tensor7 = model_with_external_data.graph.initializers[
+        )
+        external_tensor7 = model_with_external_data.graph.initializers.get_tensor(
             "tensor_ext2_1"
-        ].const_value
+        )
 
         self.assertEqual(external_tensor.numpy().tobytes(), self.data.tobytes())
         self.assertEqual(external_tensor2.numpy().tobytes(), self.data_float16.tobytes())
@@ -468,15 +468,15 @@ class OffloadExternalTensorTest(unittest.TestCase):
         )
         file_path = os.path.join(self.base_path, self.external_data_name)
         expected_tensor_order = [
-            model_with_external_data.graph.initializers["tensor2"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor_ext1_1"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor1"].const_value.tobytes(),
-            model_with_external_data.graph.initializers[
+            model_with_external_data.graph.initializers.get_tensor("tensor2").tobytes(),
+            model_with_external_data.graph.initializers.get_tensor("tensor_ext1_1").tobytes(),
+            model_with_external_data.graph.initializers.get_tensor("tensor1").tobytes(),
+            model_with_external_data.graph.initializers.get_tensor(
                 "tensor_same_file"
-            ].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor_ext1_2"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor_ext2_1"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["custom_tensor"].const_value.tobytes(),
+            ).tobytes(),
+            model_with_external_data.graph.initializers.get_tensor("tensor_ext1_2").tobytes(),
+            model_with_external_data.graph.initializers.get_tensor("tensor_ext2_1").tobytes(),
+            model_with_external_data.graph.initializers.get_tensor("custom_tensor").tobytes(),
         ]
         sorted_tensor_order = [
             self.data_float16.tobytes(),

--- a/src/onnx_ir/passes/common/constant_manipulation_test.py
+++ b/src/onnx_ir/passes/common/constant_manipulation_test.py
@@ -65,9 +65,9 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
         self.assertEqual(len(result.model.graph.initializers), 1)
         # Check the value
         self.assertEqual(
-            result.model.graph.initializers[
+            result.model.graph.initializers.get_tensor(
                 "val_0"
-            ].const_value,  # name created by name_authority
+            ),  # name created by name_authority
             constant_tensor,
         )
         # And 0 constant node
@@ -152,8 +152,8 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
                 )
         self.assertEqual(len(else_graph.initializers), 1)
         self.assertEqual(len(then_graph.initializers), 1)
-        self.assertIs(else_graph.initializers["val_0"].const_value, else_constant_tensor)
-        self.assertIs(then_graph.initializers["val_0"].const_value, then_constant_tensor)
+        self.assertIs(else_graph.initializers.get_tensor("val_0"), else_constant_tensor)
+        self.assertIs(then_graph.initializers.get_tensor("val_0"), then_constant_tensor)
 
     @parameterized.parameterized.expand(
         [
@@ -218,7 +218,7 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
             # Check that the constant node is lifted to an initializer
             self.assertEqual(len(result.model.graph.initializers), 1)
             np.testing.assert_array_equal(
-                result.model.graph.initializers["val_1"].const_value.numpy(),
+                result.model.graph.initializers.get_tensor("val_1").numpy(),
                 np.array(constant_value, dtype=np_dtype),
             )
         else:

--- a/src/onnx_ir/passes/common/initializer_deduplication_test.py
+++ b/src/onnx_ir/passes/common/initializer_deduplication_test.py
@@ -197,14 +197,14 @@ class DeduplicateInitializersTest(unittest.TestCase):
         self.apply_pass(model)
         self.assertEqual(len(model.graph.initializers), 1)
         np.testing.assert_equal(
-            model.graph.initializers["a"].const_value.numpy(), np.array(1, dtype=np.int64)
+            model.graph.initializers.get_tensor("a").numpy(), np.array(1, dtype=np.int64)
         )
         subgraph_initializers = (
             node_with_subgraph.attributes["subgraph"].as_graph().initializers
         )
         self.assertEqual(len(subgraph_initializers), 1)
         np.testing.assert_equal(
-            subgraph_initializers["b"].const_value.numpy(), np.array(1, dtype=np.int64)
+            subgraph_initializers.get_tensor("b").numpy(), np.array(1, dtype=np.int64)
         )
 
 

--- a/src/onnx_ir/passes/common/shape_inference_test.py
+++ b/src/onnx_ir/passes/common/shape_inference_test.py
@@ -114,21 +114,21 @@ class TestShapeInferencePass(unittest.TestCase):
         self.assertEqual(len(result.model.graph.inputs), 2)
         self.assertEqual(len(result.model.graph.initializers), 2)
         np.testing.assert_array_equal(
-            result.model.graph.initializers["input_b"].const_value.numpy(),
+            result.model.graph.initializers.get_tensor("input_b").numpy(),
             np.array([[42]] * big_dim, dtype=np.float32),
             strict=True,
         )
         self.assertEqual(
-            result.model.graph.initializers["input_b"].const_value.dtype,
+            result.model.graph.initializers.get_tensor("input_b").dtype,
             ir.DataType.FLOAT,
         )
         np.testing.assert_array_equal(
-            result.model.graph.initializers["initializer"].const_value.numpy(),
+            result.model.graph.initializers.get_tensor("initializer").numpy(),
             np.array([[2.0, 3.0]], dtype=np.float32),
             strict=True,
         )
         self.assertEqual(
-            result.model.graph.initializers["initializer"].const_value.dtype,
+            result.model.graph.initializers.get_tensor("initializer").dtype,
             ir.DataType.FLOAT,
         )
 
@@ -176,7 +176,7 @@ class TestShapeInferencePass(unittest.TestCase):
         self.assertEqual(len(result.model.graph.initializers), 1)
         self.assertIn("W", result.model.graph.initializers)
         self.assertIs(result.model.graph.initializers["W"], weight)
-        self.assertIsNone(result.model.graph.initializers["W"].const_value)
+        self.assertIsNone(result.model.graph.initializers.get_tensor("W"))
 
 
 if __name__ == "__main__":

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -56,7 +56,7 @@ agraph (float[1] input_x, float[2] input_y) => (float[2] result) {
         )
         np.testing.assert_array_equal(model.graph.inputs[1].const_value.numpy(), array)
         np.testing.assert_array_equal(
-            model.graph.initializers["initializer_z"].const_value.numpy(), init_array
+            model.graph.initializers.get_tensor("initializer_z").numpy(), init_array
         )
         expected_text = """\
 <


### PR DESCRIPTION
Accesses to initializer tensors across the test suite still used the old three-layer pattern (`initializers["name"].const_value`, `for value in .values(): value.const_value`) introduced before the `get_tensor()` / `tensors()` / `tensor_items()` APIs existed.

## Changes

- **`initializers["name"].const_value` → `initializers.get_tensor("name")`** — applied across `external_data_test.py`, `serde_test.py`, `_safetensors_test.py`, `_io_test.py`, `shape_inference_test.py`, `initializer_deduplication_test.py`, `constant_manipulation_test.py`
- **`for value in .values(): value.const_value` → `for tensor in .tensors()`** — where only the tensor is needed
- **`for name, value in .items(): value.const_value` → `for name, tensor in .tensor_items()`** — where name + tensor are both needed

```python
# Before
external_tensor = model.graph.initializers["tensor1"].const_value
for value in model.graph.initializers.values():
    self.assertIsInstance(value.const_value, ir.Tensor)

# After
external_tensor = model.graph.initializers.get_tensor("tensor1")
for tensor in model.graph.initializers.tensors():
    self.assertIsInstance(tensor, ir.Tensor)
```

Production code is left unchanged: those loops either require the `Value` object for operations unrelated to the tensor (naming, `replace_all_uses_with`, etc.) or deliberately skip `None` const_values — behaviour that differs from `tensors()`'s strict-raise semantics.