### PR TITLE
Support sharding plain ONNX external data

### DIFF
--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -913,6 +913,12 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             chunk_size = 1024 * 1024  # 1MB
             while bytes_to_copy > 0:
                 chunk = src.read(min(chunk_size, bytes_to_copy))
+                if not chunk:
+                    raise OSError(
+                        f"External data file {self.path!r} is shorter than expected: "
+                        f"could not read {bytes_to_copy} more byte(s) at offset "
+                        f"{(self._offset or 0) + ((self._length or self.nbytes) - bytes_to_copy)}."
+                    )
                 file.write(chunk)
                 bytes_to_copy -= len(chunk)
 

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -914,10 +914,13 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             while bytes_to_copy > 0:
                 chunk = src.read(min(chunk_size, bytes_to_copy))
                 if not chunk:
+                    failed_at_offset = (self._offset or 0) + (
+                        (self._length or self.nbytes) - bytes_to_copy
+                    )
                     raise OSError(
                         f"External data file {self.path!r} is shorter than expected: "
                         f"could not read {bytes_to_copy} more byte(s) at offset "
-                        f"{(self._offset or 0) + ((self._length or self.nbytes) - bytes_to_copy)}."
+                        f"{failed_at_offset}."
                     )
                 file.write(chunk)
                 bytes_to_copy -= len(chunk)

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -510,6 +510,33 @@ class ExternalTensorTest(unittest.TestCase):
         # Ensure repeated reads are consistent
         np.testing.assert_equal(tensor, self.data)
 
+    def test_tofile_raises_oserror_when_backing_file_is_truncated(self):
+        # tofile copies ``length`` bytes from the backing file in chunks. If
+        # the file is shorter than expected (e.g. the data file was truncated
+        # or replaced) the loop must raise an actionable OSError instead of
+        # spinning forever on empty reads.
+        external_data_name = "short.bin"
+        data = np.arange(64, dtype=np.float32)
+        full_bytes = data.tobytes()
+        data_path = pathlib.Path(self.base_path) / external_data_name
+        with open(data_path, "wb") as f:
+            f.write(full_bytes)
+        tensor = _core.ExternalTensor(
+            external_data_name,
+            offset=0,
+            length=len(full_bytes),
+            dtype=ir.DataType.FLOAT,
+            base_dir=self.base_path,
+            name="w",
+            shape=_core.Shape(data.shape),
+        )
+        # Truncate the backing file so it is shorter than ``length``.
+        with open(data_path, "wb") as f:
+            f.write(full_bytes[: len(full_bytes) // 2])
+        buffer = io.BytesIO()
+        with self.assertRaisesRegex(OSError, "shorter than expected"):
+            tensor.tofile(buffer)
+
     def test_load_raises_on_path_traversal(self):
         tensor = _core.ExternalTensor(
             "../../etc/passwd",

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -99,17 +99,24 @@ def save(
             files (e.g. ``model-00001-of-00003.data``). Because the ONNX format stores
             ``location``, ``offset``, and ``length`` per tensor, no separate index file is
             created — the saved ONNX proto itself encodes which shard each tensor lives in.
+            If a single tensor is larger than this value, it is written in its own oversized
+            shard file.
             Effective only when ``external_data`` is set.
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes.
 
     Raises:
         ValueError: If the external data path is an absolute path.
+        ValueError: If ``max_shard_size_bytes`` is not greater than 0.
     """
     if external_data is not None:
         if os.path.isabs(external_data):
             raise ValueError(
                 f"The external data path must be relative to the ONNX file path, not '{external_data}'."
+            )
+        if max_shard_size_bytes is not None and max_shard_size_bytes <= 0:
+            raise ValueError(
+                f"max_shard_size_bytes must be greater than 0, got {max_shard_size_bytes}."
             )
         base_dir = os.path.dirname(path)
 

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -110,14 +110,11 @@ def save(
         ValueError: If ``max_shard_size_bytes`` is not greater than 0.
         ValueError: If ``max_shard_size_bytes`` is set without ``external_data``.
         FileExistsError: When ``max_shard_size_bytes`` is set and any
-            destination shard file already exists on disk but is not
-            referenced by an :class:`ExternalTensor` in the model being
-            saved. TODO(justinchuby): the single-file (``max_shard_size_bytes
-            is None``) write path is currently permissive and silently
-            overwrites whatever is at ``external_data``; the collision check
-            is sharded-only because shard layouts are ambiguous (different
-            shard counts produce different filenames). The two paths should
-            eventually share the same overwrite policy.
+            destination shard file already exists on disk. The sharded write
+            path never overwrites existing files; delete the conflicting
+            files or choose a different external data path to re-save. The
+            single-file path (``max_shard_size_bytes is None``) instead
+            overwrites ``external_data`` unconditionally and never raises here.
     """
     if max_shard_size_bytes is not None and external_data is None:
         raise ValueError(

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -16,6 +16,49 @@ from onnx_ir import external_data as _external_data
 from onnx_ir._polyfill import zip
 
 
+def _read_existing_external_data_locations(
+    model_path: str | os.PathLike, base_dir: str | os.PathLike
+) -> list[str]:
+    """Return the absolute external_data file paths referenced by an existing ``.onnx``.
+
+    Used by :func:`save` to recover the set of files written by the previous
+    save of *this* model. The returned paths feed into
+    :func:`external_data.unload_from_model`'s ownership-scoped cleanup so that
+    stale shard files from a previous layout are removed without ever touching
+    shard-shaped files that happen to belong to a different model in the same
+    directory.
+
+    Returns an empty list if ``model_path`` does not exist, is not readable as
+    an ONNX proto, or contains no external initializers.
+    """
+    if not os.path.exists(model_path):
+        return []
+    try:
+        proto = onnx.load(model_path, load_external_data=False)
+    except Exception:  # pragma: no cover - best-effort recovery
+        return []
+    base_dir_str = os.fspath(base_dir) if base_dir else "."
+    locations: set[str] = set()
+
+    def _harvest(graph_proto) -> None:
+        for init in graph_proto.initializer:
+            if init.data_location != onnx.TensorProto.EXTERNAL:
+                continue
+            for entry in init.external_data:
+                if entry.key == "location":
+                    locations.add(os.path.realpath(os.path.join(base_dir_str, entry.value)))
+        for node in graph_proto.node:
+            for attr in node.attribute:
+                if attr.type == onnx.AttributeProto.GRAPH:
+                    _harvest(attr.g)
+                elif attr.type == onnx.AttributeProto.GRAPHS:
+                    for sub in attr.graphs:
+                        _harvest(sub)
+
+    _harvest(proto.graph)
+    return sorted(locations)
+
+
 def load(path: str | os.PathLike, format: str | None = None) -> _core.Model:
     """Load an ONNX model from a file.
 
@@ -126,6 +169,16 @@ def save(
             )
         base_dir = os.path.dirname(path)
 
+        # Look at the existing .onnx file at ``path`` (if any) and collect the
+        # external_data ``location`` entries it references. These count as
+        # files owned by *this* model for cleanup purposes, even when the
+        # in-memory ``model`` was constructed in-memory and has no
+        # ExternalTensor initializers to learn ownership from. This is what
+        # lets re-saving with a different shard layout (e.g. sharded → single
+        # file, or N shards → M shards) safely clean up stale shards without
+        # touching unrelated models' files sitting in the same directory.
+        prior_external_files = _read_existing_external_data_locations(path, base_dir)
+
         # Store the original initializer values so they can be restored if modify_model=False
         initialized_values: list[_core.Value] = []
         for graph in model.graphs():
@@ -141,6 +194,7 @@ def save(
                 size_threshold_bytes=size_threshold_bytes,
                 max_shard_size_bytes=max_shard_size_bytes,
                 callback=callback,
+                prior_external_files=prior_external_files,
             )
             proto = serde.serialize_model(model)
             onnx.save(proto, path, format=format)

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -44,6 +44,7 @@ def save(
     format: str | None = None,
     external_data: str | os.PathLike | None = None,
     size_threshold_bytes: int = 256,
+    max_shard_size_bytes: int | None = None,
     callback: Callable[[_protocols.TensorProtocol, _external_data.CallbackInfo], None]
     | None = None,
 ) -> None:
@@ -92,6 +93,13 @@ def save(
             it will be serialized in the ONNX Proto message.
         size_threshold_bytes: Save to external data if the tensor size in bytes is larger than this threshold.
             Effective only when ``external_data`` is set.
+        max_shard_size_bytes: Maximum cumulative size in bytes for a single external data shard file.
+            When ``None`` (the default) all external tensors are written to the single file
+            given by ``external_data``. When set, tensors are distributed across numbered shard
+            files (e.g. ``model-00001-of-00003.data``). Because the ONNX format stores
+            ``location``, ``offset``, and ``length`` per tensor, no separate index file is
+            created — the saved ONNX proto itself encodes which shard each tensor lives in.
+            Effective only when ``external_data`` is set.
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes.
 
@@ -118,6 +126,7 @@ def save(
                 base_dir,
                 external_data,
                 size_threshold_bytes=size_threshold_bytes,
+                max_shard_size_bytes=max_shard_size_bytes,
                 callback=callback,
             )
             proto = serde.serialize_model(model)

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -108,7 +108,13 @@ def save(
     Raises:
         ValueError: If the external data path is an absolute path.
         ValueError: If ``max_shard_size_bytes`` is not greater than 0.
+        ValueError: If ``max_shard_size_bytes`` is set without ``external_data``.
     """
+    if max_shard_size_bytes is not None and external_data is None:
+        raise ValueError(
+            "max_shard_size_bytes can only be used together with external_data; "
+            "set external_data to the relative path where shards should be written."
+        )
     if external_data is not None:
         if os.path.isabs(external_data):
             raise ValueError(

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -109,6 +109,15 @@ def save(
         ValueError: If the external data path is an absolute path.
         ValueError: If ``max_shard_size_bytes`` is not greater than 0.
         ValueError: If ``max_shard_size_bytes`` is set without ``external_data``.
+        FileExistsError: When ``max_shard_size_bytes`` is set and any
+            destination shard file already exists on disk but is not
+            referenced by an :class:`ExternalTensor` in the model being
+            saved. TODO(justinchuby): the single-file (``max_shard_size_bytes
+            is None``) write path is currently permissive and silently
+            overwrites whatever is at ``external_data``; the collision check
+            is sharded-only because shard layouts are ambiguous (different
+            shard counts produce different filenames). The two paths should
+            eventually share the same overwrite policy.
     """
     if max_shard_size_bytes is not None and external_data is None:
         raise ValueError(

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -16,49 +16,6 @@ from onnx_ir import external_data as _external_data
 from onnx_ir._polyfill import zip
 
 
-def _read_existing_external_data_locations(
-    model_path: str | os.PathLike, base_dir: str | os.PathLike
-) -> list[str]:
-    """Return the absolute external_data file paths referenced by an existing ``.onnx``.
-
-    Used by :func:`save` to recover the set of files written by the previous
-    save of *this* model. The returned paths feed into
-    :func:`external_data.unload_from_model`'s ownership-scoped cleanup so that
-    stale shard files from a previous layout are removed without ever touching
-    shard-shaped files that happen to belong to a different model in the same
-    directory.
-
-    Returns an empty list if ``model_path`` does not exist, is not readable as
-    an ONNX proto, or contains no external initializers.
-    """
-    if not os.path.exists(model_path):
-        return []
-    try:
-        proto = onnx.load(model_path, load_external_data=False)
-    except Exception:  # pragma: no cover - best-effort recovery
-        return []
-    base_dir_str = os.fspath(base_dir) if base_dir else "."
-    locations: set[str] = set()
-
-    def _harvest(graph_proto) -> None:
-        for init in graph_proto.initializer:
-            if init.data_location != onnx.TensorProto.EXTERNAL:
-                continue
-            for entry in init.external_data:
-                if entry.key == "location":
-                    locations.add(os.path.realpath(os.path.join(base_dir_str, entry.value)))
-        for node in graph_proto.node:
-            for attr in node.attribute:
-                if attr.type == onnx.AttributeProto.GRAPH:
-                    _harvest(attr.g)
-                elif attr.type == onnx.AttributeProto.GRAPHS:
-                    for sub in attr.graphs:
-                        _harvest(sub)
-
-    _harvest(proto.graph)
-    return sorted(locations)
-
-
 def load(path: str | os.PathLike, format: str | None = None) -> _core.Model:
     """Load an ONNX model from a file.
 
@@ -169,16 +126,6 @@ def save(
             )
         base_dir = os.path.dirname(path)
 
-        # Look at the existing .onnx file at ``path`` (if any) and collect the
-        # external_data ``location`` entries it references. These count as
-        # files owned by *this* model for cleanup purposes, even when the
-        # in-memory ``model`` was constructed in-memory and has no
-        # ExternalTensor initializers to learn ownership from. This is what
-        # lets re-saving with a different shard layout (e.g. sharded → single
-        # file, or N shards → M shards) safely clean up stale shards without
-        # touching unrelated models' files sitting in the same directory.
-        prior_external_files = _read_existing_external_data_locations(path, base_dir)
-
         # Store the original initializer values so they can be restored if modify_model=False
         initialized_values: list[_core.Value] = []
         for graph in model.graphs():
@@ -194,7 +141,6 @@ def save(
                 size_threshold_bytes=size_threshold_bytes,
                 max_shard_size_bytes=max_shard_size_bytes,
                 callback=callback,
-                prior_external_files=prior_external_files,
             )
             proto = serde.serialize_model(model)
             onnx.save(proto, path, format=format)

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -103,18 +103,25 @@ class IOFunctionsTest(unittest.TestCase):
 
     def test_save_with_sharding_creates_multiple_shard_files(self):
         """Test that max_shard_size_bytes creates multiple numbered shard files."""
+
         # Build a model with 3 tensors, each ~400 bytes (100 float32 elements)
         def make_init(name: str, n: int) -> ir.Value:
             arr = np.zeros(n, dtype=np.float32)
             t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
-            return ir.Value(name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype))
+            return ir.Value(
+                name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype)
+            )
 
         inits = [make_init(f"w{i}", 100) for i in range(3)]
         node = ir.Node("", "Identity", inputs=(inits[0],))
         node.outputs[0].name = "out"
         node.outputs[0].dtype = ir.DataType.FLOAT
         graph = ir.Graph(
-            inputs=inits, outputs=list(node.outputs), nodes=[node], initializers=inits, name="g"
+            inputs=inits,
+            outputs=list(node.outputs),
+            nodes=[node],
+            initializers=inits,
+            name="g",
         )
         model = ir.Model(graph, ir_version=10)
 
@@ -162,7 +169,6 @@ class IOFunctionsTest(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "model.data")))
             shard_files = [f for f in os.listdir(tmpdir) if "of-" in f]
             self.assertEqual(shard_files, [], "Should not create numbered shard files")
-
 
         model = _create_simple_model_with_initializers()
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -193,6 +193,15 @@ class IOFunctionsTest(unittest.TestCase):
                     max_shard_size_bytes=0,
                 )
 
+    def test_save_raise_when_max_shard_size_bytes_without_external_data(self):
+        model = _create_simple_model_with_initializers()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            with self.assertRaisesRegex(
+                ValueError, "max_shard_size_bytes can only be used together with external_data"
+            ):
+                _io.save(model, path, max_shard_size_bytes=1024)
+
     def test_save_with_sharding_removes_stale_shard_files(self):
         def make_init(name: str, n: int) -> ir.Value:
             arr = np.zeros(n, dtype=np.float32)

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -359,6 +359,56 @@ class IOFunctionsTest(unittest.TestCase):
                     reloaded.graph.initializers[f"w{i}"].const_value.numpy(), expected
                 )
 
+    def test_resave_same_shard_count_with_boundary_shift_preserves_data(self):
+        # Round-4 regression (@titaiwangms): when the new shard layout has the
+        # *same* shard count but a tensor migrates from shard i to shard j > i,
+        # a per-shard materialization pass would still leave that tensor
+        # pointing at file i while we are writing shard j. By the time shard i
+        # is rewritten and truncated, the migrated tensor's data is gone. The
+        # fix is a global pre-materialization pass across all destination
+        # paths before any shard is opened for writing.
+        model, _arrs = self._make_sharded_test_model([75, 75, 75, 125])
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            # First save: layout is [w0,w1,w2][w3] (2 shards under 900 bytes).
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=900,
+            )
+            loaded = _io.load(path)
+            # Enlarge w1 so the shard boundary shifts: new layout is
+            # [w0,w1][w2,w3] — still 2 shards, but w2 migrates from shard 1
+            # to shard 2.
+            big = np.arange(150, dtype=np.float32) + 10000
+            loaded.graph.initializers["w1"].const_value = ir.tensor(big, name="w1")
+            _io.save(
+                loaded,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=900,
+            )
+            reloaded = _io.load(path)
+            # w2's original data must survive even though its shard changed.
+            np.testing.assert_array_equal(
+                reloaded.graph.initializers["w2"].const_value.numpy(),
+                np.arange(75, dtype=np.float32),
+            )
+            np.testing.assert_array_equal(
+                reloaded.graph.initializers["w0"].const_value.numpy(),
+                np.arange(75, dtype=np.float32),
+            )
+            np.testing.assert_array_equal(
+                reloaded.graph.initializers["w1"].const_value.numpy(), big
+            )
+            np.testing.assert_array_equal(
+                reloaded.graph.initializers["w3"].const_value.numpy(),
+                np.arange(125, dtype=np.float32),
+            )
+
     def test_resave_loaded_sharded_model_as_single_file_preserves_data(self):
         # sharded -> non-sharded (max_shard_size_bytes=None) transition. The
         # single-file write path is permissive and just overwrites model.data;

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -249,7 +249,58 @@ class IOFunctionsTest(unittest.TestCase):
             for p in unrelated:
                 self.assertTrue(os.path.exists(p))
 
-    def test_save_loaded_sharded_model_with_different_limit_preserves_data(self):
+    def test_save_loaded_sharded_model_in_place_raises(self):
+        # The sharded write path never overwrites pre-existing shard files, so
+        # re-saving a loaded sharded model to the *same* base name raises
+        # FileExistsError (the destination shards already exist on disk).
+        def make_init(name: str, n: int) -> tuple[ir.Value, np.ndarray]:
+            arr = np.arange(n, dtype=np.float32)
+            t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
+            value = ir.Value(
+                name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype)
+            )
+            return value, arr
+
+        init_0, _ = make_init("w0", 150)  # 600 bytes
+        init_1, _ = make_init("w1", 100)  # 400 bytes
+        init_2, _ = make_init("w2", 100)  # 400 bytes
+        inits = [init_0, init_1, init_2]
+        node = ir.Node("", "Identity", inputs=(inits[0],))
+        node.outputs[0].name = "out"
+        node.outputs[0].dtype = ir.DataType.FLOAT
+        graph = ir.Graph(
+            inputs=inits,
+            outputs=list(node.outputs),
+            nodes=[node],
+            initializers=inits,
+            name="g",
+        )
+        model = ir.Model(graph, ir_version=10)
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=1000,
+            )
+            loaded = _io.load(path)
+            with self.assertRaisesRegex(FileExistsError, "Refusing to overwrite"):
+                _io.save(
+                    loaded,
+                    path,
+                    external_data="model.data",
+                    size_threshold_bytes=0,
+                    max_shard_size_bytes=800,
+                )
+
+    def test_resave_loaded_sharded_model_to_new_path_preserves_data(self):
+        # The escape hatch for re-saving a loaded sharded model: write to a
+        # *different* external data base name. The source shards are never
+        # touched, so no materialization is needed and the data round-trips
+        # cleanly even when the new layout has a different shard count.
         def make_init(name: str, n: int) -> tuple[ir.Value, np.ndarray]:
             arr = np.arange(n, dtype=np.float32)
             t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
@@ -284,14 +335,17 @@ class IOFunctionsTest(unittest.TestCase):
                 max_shard_size_bytes=1000,
             )
             loaded = _io.load(path)
+            # Re-save to a different base name with a different limit (shard
+            # count changes from 2 -> 3).
+            path2 = os.path.join(tmpdir, "model2.onnx")
             _io.save(
                 loaded,
-                path,
-                external_data="model.data",
+                path2,
+                external_data="model2.data",
                 size_threshold_bytes=0,
                 max_shard_size_bytes=800,
             )
-            reloaded = _io.load(path)
+            reloaded = _io.load(path2)
             np.testing.assert_array_equal(
                 reloaded.graph.initializers["w0"].const_value.numpy(), arr_0
             )
@@ -329,12 +383,12 @@ class IOFunctionsTest(unittest.TestCase):
         return ir.Model(graph, ir_version=10), arrs
 
     def test_resave_loaded_model_with_changed_shard_count_preserves_data(self):
-        # Round-2 regression: re-saving a loaded sharded model with a *different*
-        # shard count used to crash with FileNotFoundError because the old
-        # shards (under different names) got deleted before being read. With
-        # the simplified contract there is no automatic cleanup at all, so the
-        # old shard files remain on disk as garbage — but the new save still
-        # succeeds and the data round-trips cleanly via ir.load.
+        # When the new layout has a *different* shard count, the new shard
+        # filenames (``-of-00002``) don't collide with the old ones
+        # (``-of-00004``), so the save succeeds without overwriting anything.
+        # The old shard files remain on disk as garbage (cleanup is the
+        # caller's responsibility), but the data round-trips cleanly because
+        # the new shards are written by reading the still-present old shards.
         model, arrs = self._make_sharded_test_model([125, 125, 125, 125])
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")
@@ -359,18 +413,15 @@ class IOFunctionsTest(unittest.TestCase):
                     reloaded.graph.initializers[f"w{i}"].const_value.numpy(), expected
                 )
 
-    def test_resave_same_shard_count_with_boundary_shift_preserves_data(self):
-        # Round-4 regression (@titaiwangms): when the new shard layout has the
-        # *same* shard count but a tensor migrates from shard i to shard j > i,
-        # a per-shard materialization pass would still leave that tensor
-        # pointing at file i while we are writing shard j. By the time shard i
-        # is rewritten and truncated, the migrated tensor's data is gone. The
-        # fix is a global pre-materialization pass across all destination
-        # paths before any shard is opened for writing.
+    def test_resave_same_shard_count_with_boundary_shift_in_place_raises(self):
+        # Even when the new layout keeps the *same* shard count, re-saving in
+        # place still collides with the existing shard files and raises. This
+        # is the simplified replacement for the old self-overwrite support:
+        # rather than materializing every migrating tensor to survive an
+        # in-place rewrite, the sharded path simply refuses to overwrite.
         model, _arrs = self._make_sharded_test_model([75, 75, 75, 125])
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")
-            # First save: layout is [w0,w1,w2][w3] (2 shards under 900 bytes).
             _io.save(
                 model,
                 path,
@@ -379,35 +430,16 @@ class IOFunctionsTest(unittest.TestCase):
                 max_shard_size_bytes=900,
             )
             loaded = _io.load(path)
-            # Enlarge w1 so the shard boundary shifts: new layout is
-            # [w0,w1][w2,w3] — still 2 shards, but w2 migrates from shard 1
-            # to shard 2.
             big = np.arange(150, dtype=np.float32) + 10000
             loaded.graph.initializers["w1"].const_value = ir.tensor(big, name="w1")
-            _io.save(
-                loaded,
-                path,
-                external_data="model.data",
-                size_threshold_bytes=0,
-                max_shard_size_bytes=900,
-            )
-            reloaded = _io.load(path)
-            # w2's original data must survive even though its shard changed.
-            np.testing.assert_array_equal(
-                reloaded.graph.initializers["w2"].const_value.numpy(),
-                np.arange(75, dtype=np.float32),
-            )
-            np.testing.assert_array_equal(
-                reloaded.graph.initializers["w0"].const_value.numpy(),
-                np.arange(75, dtype=np.float32),
-            )
-            np.testing.assert_array_equal(
-                reloaded.graph.initializers["w1"].const_value.numpy(), big
-            )
-            np.testing.assert_array_equal(
-                reloaded.graph.initializers["w3"].const_value.numpy(),
-                np.arange(125, dtype=np.float32),
-            )
+            with self.assertRaisesRegex(FileExistsError, "Refusing to overwrite"):
+                _io.save(
+                    loaded,
+                    path,
+                    external_data="model.data",
+                    size_threshold_bytes=0,
+                    max_shard_size_bytes=900,
+                )
 
     def test_resave_loaded_sharded_model_as_single_file_preserves_data(self):
         # sharded -> non-sharded (max_shard_size_bytes=None) transition. The

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -170,6 +170,7 @@ class IOFunctionsTest(unittest.TestCase):
             shard_files = [f for f in os.listdir(tmpdir) if "of-" in f]
             self.assertEqual(shard_files, [], "Should not create numbered shard files")
 
+    def test_save_raise_when_external_data_is_not_relative_path(self):
         model = _create_simple_model_with_initializers()
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -299,6 +299,132 @@ class IOFunctionsTest(unittest.TestCase):
                 reloaded.graph.initializers["w2"].const_value.numpy(), arr_2
             )
 
+    def _make_sharded_test_model(self, sizes):
+        """Build a tiny model with one initializer per ``sizes`` element."""
+
+        def make_init(name, n):
+            arr = np.arange(n, dtype=np.float32)
+            t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
+            return (
+                ir.Value(name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype)),
+                arr,
+            )
+
+        pairs = [make_init(f"w{i}", n) for i, n in enumerate(sizes)]
+        inits = [v for v, _ in pairs]
+        arrs = [a for _, a in pairs]
+        node = ir.Node("", "Identity", inputs=(inits[0],))
+        node.outputs[0].name = "out"
+        node.outputs[0].dtype = ir.DataType.FLOAT
+        graph = ir.Graph(
+            inputs=inits,
+            outputs=list(node.outputs),
+            nodes=[node],
+            initializers=inits,
+            name="g",
+        )
+        return ir.Model(graph, ir_version=10), arrs
+
+    def test_resave_loaded_model_with_changed_shard_count_preserves_data(self):
+        # Round-2 regression: re-saving a loaded sharded model with a *different*
+        # shard count used to crash with FileNotFoundError because
+        # _materialize_external_tensors_for_destination_paths only protected
+        # tensors matching a new destination path, and the old shards (under
+        # different names) were deleted before being read.
+        # Save 4 tensors of 125 floats each (500 bytes each) -> 4 shards at
+        # max_shard_size_bytes=500, then re-save at 1500 -> ~2 shards.
+        model, arrs = self._make_sharded_test_model([125, 125, 125, 125])
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=500,
+            )
+            first_layout = sorted(
+                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
+            )
+            self.assertGreaterEqual(len(first_layout), 2)
+            loaded = _io.load(path)
+            _io.save(
+                loaded,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=1500,
+            )
+            second_layout = sorted(
+                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
+            )
+            self.assertNotEqual(first_layout, second_layout)
+            # Old layout's shard files must be gone (stale cleanup) and
+            # no old-layout shard should survive into the new layout's
+            # filename set.
+            for old_name in first_layout:
+                if old_name not in second_layout:
+                    self.assertFalse(os.path.exists(os.path.join(tmpdir, old_name)))
+            reloaded = _io.load(path)
+            for i, expected in enumerate(arrs):
+                np.testing.assert_array_equal(
+                    reloaded.graph.initializers[f"w{i}"].const_value.numpy(), expected
+                )
+
+    def test_resave_loaded_sharded_model_as_single_file_preserves_data(self):
+        # sharded -> non-sharded transition: stale ``-of-`` files must be
+        # cleaned up and the single ``model.data`` written successfully.
+        model, arrs = self._make_sharded_test_model([100, 100, 100])
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=500,
+            )
+            loaded = _io.load(path)
+            _io.save(
+                loaded,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+            )
+            stale_shards = [
+                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
+            ]
+            self.assertEqual(stale_shards, [])
+            self.assertTrue(os.path.exists(os.path.join(tmpdir, "model.data")))
+            reloaded = _io.load(path)
+            for i, expected in enumerate(arrs):
+                np.testing.assert_array_equal(
+                    reloaded.graph.initializers[f"w{i}"].const_value.numpy(), expected
+                )
+
+    def test_save_does_not_delete_unrelated_models_shards(self):
+        # Regression test for cross-model deletion: an unrelated model's
+        # ``model-NNNNN-of-NNNNN.data`` files sitting in the same directory
+        # must survive a save of an unrelated model under the same base name.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            unrelated = [
+                os.path.join(tmpdir, f"model-{i:05d}-of-00009.data") for i in range(1, 10)
+            ]
+            for p in unrelated:
+                with open(p, "wb") as f:
+                    f.write(b"unrelated")
+            model, _ = self._make_sharded_test_model([200, 200])
+            path = os.path.join(tmpdir, "model.onnx")
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=500,
+            )
+            for p in unrelated:
+                self.assertTrue(os.path.exists(p), f"unrelated shard {p} was deleted")
+
     def test_save_with_external_data_invalidates_obsolete_external_tensors(self):
         model = _create_simple_model_with_initializers()
         self.assertIsInstance(model.graph.initializers["initializer_0"].const_value, ir.Tensor)

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -202,38 +202,43 @@ class IOFunctionsTest(unittest.TestCase):
             ):
                 _io.save(model, path, max_shard_size_bytes=1024)
 
-    def test_save_with_sharding_removes_stale_shard_files(self):
-        def make_init(name: str, n: int) -> ir.Value:
-            arr = np.zeros(n, dtype=np.float32)
-            t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
-            return ir.Value(
-                name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype)
-            )
-
-        inits = [make_init(f"w{i}", 100) for i in range(3)]
-        node = ir.Node("", "Identity", inputs=(inits[0],))
-        node.outputs[0].name = "out"
-        node.outputs[0].dtype = ir.DataType.FLOAT
-        graph = ir.Graph(
-            inputs=inits,
-            outputs=list(node.outputs),
-            nodes=[node],
-            initializers=inits,
-            name="g",
-        )
-        model = ir.Model(graph, ir_version=10)
-
+    def test_save_sharded_raises_on_foreign_shard_collision(self):
+        # The sharded write path refuses to silently clobber existing shard
+        # files that aren't already part of the model being saved. This is
+        # what enforces "the user knows whose files live in this directory"
+        # without bringing back the (very error-prone) stem-based cleanup.
+        # 2 initializers + max_shard_size_bytes=200 forces a 2-shard layout
+        # whose first shard collides with the foreign file below.
+        model, _arrs = self._make_sharded_test_model([100, 100])
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            foreign = os.path.join(tmpdir, "model-00001-of-00002.data")
+            with open(foreign, "wb") as f:
+                f.write(b"foreign")
             path = os.path.join(tmpdir, "model.onnx")
-            _io.save(
-                model,
-                path,
-                external_data="model.data",
-                size_threshold_bytes=0,
-                max_shard_size_bytes=400,
-            )
-            self.assertTrue(os.path.exists(os.path.join(tmpdir, "model-00003-of-00003.data")))
+            with self.assertRaisesRegex(FileExistsError, "Refusing to overwrite"):
+                _io.save(
+                    model,
+                    path,
+                    external_data="model.data",
+                    size_threshold_bytes=0,
+                    max_shard_size_bytes=200,
+                )
+            # The foreign file must remain untouched after the raise.
+            with open(foreign, "rb") as f:
+                self.assertEqual(f.read(), b"foreign")
 
+    def test_save_sharded_does_not_raise_on_unrelated_shard_files(self):
+        # An unrelated model's shards sitting in the same directory but
+        # with *different* filenames must not block our save.
+        model = _create_simple_model_with_initializers()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            unrelated = [
+                os.path.join(tmpdir, f"other-{i:05d}-of-00009.data") for i in range(1, 10)
+            ]
+            for p in unrelated:
+                with open(p, "wb") as f:
+                    f.write(b"unrelated")
+            path = os.path.join(tmpdir, "model.onnx")
             _io.save(
                 model,
                 path,
@@ -241,10 +246,8 @@ class IOFunctionsTest(unittest.TestCase):
                 size_threshold_bytes=0,
                 max_shard_size_bytes=10_000_000,
             )
-            stale_shards = [
-                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
-            ]
-            self.assertEqual(stale_shards, [])
+            for p in unrelated:
+                self.assertTrue(os.path.exists(p))
 
     def test_save_loaded_sharded_model_with_different_limit_preserves_data(self):
         def make_init(name: str, n: int) -> tuple[ir.Value, np.ndarray]:
@@ -327,12 +330,11 @@ class IOFunctionsTest(unittest.TestCase):
 
     def test_resave_loaded_model_with_changed_shard_count_preserves_data(self):
         # Round-2 regression: re-saving a loaded sharded model with a *different*
-        # shard count used to crash with FileNotFoundError because
-        # _materialize_external_tensors_for_destination_paths only protected
-        # tensors matching a new destination path, and the old shards (under
-        # different names) were deleted before being read.
-        # Save 4 tensors of 125 floats each (500 bytes each) -> 4 shards at
-        # max_shard_size_bytes=500, then re-save at 1500 -> ~2 shards.
+        # shard count used to crash with FileNotFoundError because the old
+        # shards (under different names) got deleted before being read. With
+        # the simplified contract there is no automatic cleanup at all, so the
+        # old shard files remain on disk as garbage — but the new save still
+        # succeeds and the data round-trips cleanly via ir.load.
         model, arrs = self._make_sharded_test_model([125, 125, 125, 125])
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")
@@ -343,10 +345,6 @@ class IOFunctionsTest(unittest.TestCase):
                 size_threshold_bytes=0,
                 max_shard_size_bytes=500,
             )
-            first_layout = sorted(
-                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
-            )
-            self.assertGreaterEqual(len(first_layout), 2)
             loaded = _io.load(path)
             _io.save(
                 loaded,
@@ -355,16 +353,6 @@ class IOFunctionsTest(unittest.TestCase):
                 size_threshold_bytes=0,
                 max_shard_size_bytes=1500,
             )
-            second_layout = sorted(
-                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
-            )
-            self.assertNotEqual(first_layout, second_layout)
-            # Old layout's shard files must be gone (stale cleanup) and
-            # no old-layout shard should survive into the new layout's
-            # filename set.
-            for old_name in first_layout:
-                if old_name not in second_layout:
-                    self.assertFalse(os.path.exists(os.path.join(tmpdir, old_name)))
             reloaded = _io.load(path)
             for i, expected in enumerate(arrs):
                 np.testing.assert_array_equal(
@@ -372,8 +360,10 @@ class IOFunctionsTest(unittest.TestCase):
                 )
 
     def test_resave_loaded_sharded_model_as_single_file_preserves_data(self):
-        # sharded -> non-sharded transition: stale ``-of-`` files must be
-        # cleaned up and the single ``model.data`` written successfully.
+        # sharded -> non-sharded (max_shard_size_bytes=None) transition. The
+        # single-file write path is permissive and just overwrites model.data;
+        # old shard files remain (cleanup is the caller's responsibility), but
+        # the round-tripped data must be correct.
         model, arrs = self._make_sharded_test_model([100, 100, 100])
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")
@@ -391,10 +381,6 @@ class IOFunctionsTest(unittest.TestCase):
                 external_data="model.data",
                 size_threshold_bytes=0,
             )
-            stale_shards = [
-                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
-            ]
-            self.assertEqual(stale_shards, [])
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "model.data")))
             reloaded = _io.load(path)
             for i, expected in enumerate(arrs):
@@ -405,7 +391,9 @@ class IOFunctionsTest(unittest.TestCase):
     def test_save_does_not_delete_unrelated_models_shards(self):
         # Regression test for cross-model deletion: an unrelated model's
         # ``model-NNNNN-of-NNNNN.data`` files sitting in the same directory
-        # must survive a save of an unrelated model under the same base name.
+        # must survive a save of an unrelated model under the same base name
+        # *as long as the filenames don't collide*. (A direct collision is now
+        # a FileExistsError, exercised by test_save_sharded_raises_on_foreign_shard_collision.)
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             unrelated = [
                 os.path.join(tmpdir, f"model-{i:05d}-of-00009.data") for i in range(1, 10)

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -101,7 +101,69 @@ class IOFunctionsTest(unittest.TestCase):
         np.testing.assert_array_equal(initializer_tensor.numpy(), np.array([0.0]))
         np.testing.assert_array_equal(const_attr_tensor.numpy(), np.array([1.0]))
 
-    def test_save_raise_when_external_data_is_not_relative_path(self):
+    def test_save_with_sharding_creates_multiple_shard_files(self):
+        """Test that max_shard_size_bytes creates multiple numbered shard files."""
+        # Build a model with 3 tensors, each ~400 bytes (100 float32 elements)
+        def make_init(name: str, n: int) -> ir.Value:
+            arr = np.zeros(n, dtype=np.float32)
+            t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
+            return ir.Value(name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype))
+
+        inits = [make_init(f"w{i}", 100) for i in range(3)]
+        node = ir.Node("", "Identity", inputs=(inits[0],))
+        node.outputs[0].name = "out"
+        node.outputs[0].dtype = ir.DataType.FLOAT
+        graph = ir.Graph(
+            inputs=inits, outputs=list(node.outputs), nodes=[node], initializers=inits, name="g"
+        )
+        model = ir.Model(graph, ir_version=10)
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            # 400-byte limit forces each 400-byte tensor into its own shard
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=400,
+            )
+
+            self.assertTrue(os.path.exists(path))
+            shard_files = sorted(
+                f for f in os.listdir(tmpdir) if f.startswith("model-") and f.endswith(".data")
+            )
+            self.assertGreater(len(shard_files), 1, "Expected multiple shard files")
+
+            # Load back and verify data integrity
+            loaded = _io.load(path)
+            for i, init in enumerate(inits):
+                loaded_tensor = loaded.graph.initializers[f"w{i}"].const_value
+                self.assertIsInstance(loaded_tensor, ir.ExternalTensor)
+                np.testing.assert_array_equal(loaded_tensor.numpy(), init.const_value.numpy())
+
+        # Original model must be unchanged (in-memory tensors)
+        for init in inits:
+            self.assertIsInstance(init.const_value, ir.Tensor)
+            self.assertNotIsInstance(init.const_value, ir.ExternalTensor)
+
+    def test_save_with_sharding_single_shard_uses_base_name(self):
+        """When tensors fit in one shard the file keeps its original name."""
+        model = _create_simple_model_with_initializers()
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=10_000_000,
+            )
+            self.assertTrue(os.path.exists(os.path.join(tmpdir, "model.data")))
+            shard_files = [f for f in os.listdir(tmpdir) if "of-" in f]
+            self.assertEqual(shard_files, [], "Should not create numbered shard files")
+
+
         model = _create_simple_model_with_initializers()
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "model.onnx")

--- a/src/onnx_ir/_io_test.py
+++ b/src/onnx_ir/_io_test.py
@@ -178,6 +178,118 @@ class IOFunctionsTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 _io.save(model, path, external_data=external_data_file)
 
+    def test_save_raise_when_max_shard_size_bytes_is_not_positive(self):
+        model = _create_simple_model_with_initializers()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            with self.assertRaisesRegex(
+                ValueError, "max_shard_size_bytes must be greater than 0"
+            ):
+                _io.save(
+                    model,
+                    path,
+                    external_data="model.data",
+                    size_threshold_bytes=0,
+                    max_shard_size_bytes=0,
+                )
+
+    def test_save_with_sharding_removes_stale_shard_files(self):
+        def make_init(name: str, n: int) -> ir.Value:
+            arr = np.zeros(n, dtype=np.float32)
+            t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
+            return ir.Value(
+                name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype)
+            )
+
+        inits = [make_init(f"w{i}", 100) for i in range(3)]
+        node = ir.Node("", "Identity", inputs=(inits[0],))
+        node.outputs[0].name = "out"
+        node.outputs[0].dtype = ir.DataType.FLOAT
+        graph = ir.Graph(
+            inputs=inits,
+            outputs=list(node.outputs),
+            nodes=[node],
+            initializers=inits,
+            name="g",
+        )
+        model = ir.Model(graph, ir_version=10)
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=400,
+            )
+            self.assertTrue(os.path.exists(os.path.join(tmpdir, "model-00003-of-00003.data")))
+
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=10_000_000,
+            )
+            stale_shards = [
+                f for f in os.listdir(tmpdir) if f.startswith("model-") and "-of-" in f
+            ]
+            self.assertEqual(stale_shards, [])
+
+    def test_save_loaded_sharded_model_with_different_limit_preserves_data(self):
+        def make_init(name: str, n: int) -> tuple[ir.Value, np.ndarray]:
+            arr = np.arange(n, dtype=np.float32)
+            t = ir.tensor(arr, dtype=ir.DataType.FLOAT, name=name)
+            value = ir.Value(
+                name=name, const_value=t, shape=t.shape, type=ir.TensorType(t.dtype)
+            )
+            return value, arr
+
+        init_0, arr_0 = make_init("w0", 150)  # 600 bytes
+        init_1, arr_1 = make_init("w1", 100)  # 400 bytes
+        init_2, arr_2 = make_init("w2", 100)  # 400 bytes
+        inits = [init_0, init_1, init_2]
+        node = ir.Node("", "Identity", inputs=(inits[0],))
+        node.outputs[0].name = "out"
+        node.outputs[0].dtype = ir.DataType.FLOAT
+        graph = ir.Graph(
+            inputs=inits,
+            outputs=list(node.outputs),
+            nodes=[node],
+            initializers=inits,
+            name="g",
+        )
+        model = ir.Model(graph, ir_version=10)
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            path = os.path.join(tmpdir, "model.onnx")
+            _io.save(
+                model,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=1000,
+            )
+            loaded = _io.load(path)
+            _io.save(
+                loaded,
+                path,
+                external_data="model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=800,
+            )
+            reloaded = _io.load(path)
+            np.testing.assert_array_equal(
+                reloaded.graph.initializers["w0"].const_value.numpy(), arr_0
+            )
+            np.testing.assert_array_equal(
+                reloaded.graph.initializers["w1"].const_value.numpy(), arr_1
+            )
+            np.testing.assert_array_equal(
+                reloaded.graph.initializers["w2"].const_value.numpy(), arr_2
+            )
+
     def test_save_with_external_data_invalidates_obsolete_external_tensors(self):
         model = _create_simple_model_with_initializers()
         self.assertIsInstance(model.graph.initializers["initializer_0"].const_value, ir.Tensor)

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -542,10 +542,14 @@ def unload_from_model(
         global_index = 0
 
         for shard_idx, shard_tensor_list in enumerate(tensor_shards, start=1):
-            shard_relative_path = _get_shard_filename(str(relative_path), shard_idx, total_shards)
+            shard_relative_path = _get_shard_filename(
+                str(relative_path), shard_idx, total_shards
+            )
 
             # Wrap the callback so that index/total reflect the global position across shards
-            shard_callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None
+            shard_callback: (
+                Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None
+            ) = None
             if callback is not None:
 
                 def _make_shard_callback(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -432,10 +432,8 @@ def _check_no_foreign_shard_collisions(
         listing = ", ".join(repr(p) for p in foreign)
         raise FileExistsError(
             "Refusing to overwrite existing external data file(s) that are not "
-            f"referenced by the model being saved: {listing}. Either delete "
-            "these files first, save into a clean directory, or load the model "
-            "with ir.load() before re-saving so the conflicting files are "
-            "recognized as part of this model."
+            f"referenced by the model being saved: {listing}. Delete the "
+            "conflicting files or save into a different directory."
         )
 
 
@@ -684,8 +682,8 @@ def unload_from_model(
             but is not referenced by an :class:`ExternalTensor` in the model
             being saved. This prevents silently overwriting another model's
             shard data that happens to share the same base name. Callers
-            should either save into a clean directory or load the model with
-            :func:`load` before re-saving.
+            should delete the conflicting files or save into a different
+            directory.
     """
     if max_shard_size_bytes is not None and max_shard_size_bytes <= 0:
         raise ValueError(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -18,6 +18,7 @@ __all__ = [
 import dataclasses
 import logging
 import os
+import re
 from collections.abc import Iterator, Sequence
 
 from onnx_ir import _core, _enums, _protocols
@@ -132,16 +133,34 @@ def _get_shard_filename(base_name: str, shard_idx: int, total_shards: int) -> st
     if total_shards == 1:
         return base_name
 
-    # Extract extension
-    if "." in base_name:
-        name, ext = base_name.rsplit(".", 1)
-        ext = f".{ext}"
-    else:
-        name = base_name
-        ext = ""
+    dir_name, filename = os.path.split(base_name)
+    name, ext = os.path.splitext(filename)
 
     # Always use 5 digits to follow transformers convention
-    return f"{name}-{shard_idx:05d}-of-{total_shards:05d}{ext}"
+    shard_filename = f"{name}-{shard_idx:05d}-of-{total_shards:05d}{ext}"
+    return os.path.join(dir_name, shard_filename) if dir_name else shard_filename
+
+
+def _make_shard_callback(
+    callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None],
+    total: int,
+    index_offset: int,
+) -> Callable[[_protocols.TensorProtocol, CallbackInfo], None]:
+    def _shard_callback(
+        tensor: _protocols.TensorProtocol,
+        info: CallbackInfo,
+    ) -> None:
+        callback(
+            tensor,
+            CallbackInfo(
+                total=total,
+                index=index_offset + info.index,
+                offset=info.offset,
+                filename=info.filename,
+            ),
+        )
+
+    return _shard_callback
 
 
 def _shard_tensors(
@@ -163,18 +182,23 @@ def _shard_tensors(
         A list of tensor groups, one per shard.
     """
     shards: list[list[_protocols.TensorProtocol]] = [[]]
-    current_shard_size = 0
 
     for tensor in tensors:
+        if tensor.nbytes > max_shard_size_bytes:
+            logger.warning(
+                "Tensor %s (%d bytes) exceeds max_shard_size_bytes=%d and will be written in an oversized shard.",
+                tensor.name,
+                tensor.nbytes,
+                max_shard_size_bytes,
+            )
         projected_shard_size = _estimate_shard_size_bytes([*shards[-1], tensor])
         # Start a new shard when the current one would be exceeded
         # (but never leave a shard empty).
-        if projected_shard_size > max_shard_size_bytes and current_shard_size > 0:
+        if projected_shard_size > max_shard_size_bytes and len(shards[-1]) > 0:
             shards.append([])
             projected_shard_size = _estimate_shard_size_bytes([tensor])
 
         shards[-1].append(tensor)
-        current_shard_size = projected_shard_size
 
     return shards
 
@@ -234,6 +258,75 @@ def _estimate_shard_size_bytes(tensors: Sequence[_protocols.TensorProtocol]) -> 
         current_offset = _compute_new_offset(current_offset, tensor.nbytes)
         current_offset += tensor.nbytes
     return current_offset
+
+
+def _normalize_existing_path(path: str | os.PathLike) -> str | None:
+    if not os.path.exists(path):
+        return None
+    return os.path.normcase(os.path.realpath(path))
+
+
+def _materialize_external_tensors_for_destination_paths(
+    tensors: Sequence[_protocols.TensorProtocol],
+    destination_paths: Sequence[str | os.PathLike],
+) -> list[_protocols.TensorProtocol]:
+    normalized_destination_paths = {
+        normalized_path
+        for path in destination_paths
+        if (normalized_path := _normalize_existing_path(path)) is not None
+    }
+    if not normalized_destination_paths:
+        return list(tensors)
+
+    converted_tensors: list[_protocols.TensorProtocol] = []
+    for tensor in tensors:
+        normalized_tensor_path = (
+            _normalize_existing_path(tensor.path)
+            if isinstance(tensor, _core.ExternalTensor)
+            else None
+        )
+        if normalized_tensor_path in normalized_destination_paths:
+            # FIXME(shubhambhokare1): If there is a non-initializer tensor that
+            # is referring to this file, that tensor is now invalid.
+            # This is a special case we are ok not handling right now.
+            converted_tensors.append(_external_tensor_to_memory_tensor(tensor))
+            # Mark the original external tensor as invalid because it is now pointing
+            # to a file that is going to be overwritten.
+            tensor.invalidate()
+            logger.warning(
+                "External tensor %s is referring to the destination path. "
+                "It has been invalidated because the data file is changed. To avoid this, "
+                "save the external data to a different path or load the newly saved model back "
+                "with ir.load().",
+                tensor,
+            )
+        else:
+            converted_tensors.append(tensor)
+
+    return converted_tensors
+
+
+def _cleanup_stale_shard_files(
+    base_dir: str | os.PathLike,
+    relative_path: str | os.PathLike,
+    total_shards: int,
+) -> None:
+    path_str = str(relative_path)
+    dir_name, file_name = os.path.split(path_str)
+    stem, ext = os.path.splitext(file_name)
+    shard_dir = os.path.join(base_dir, dir_name) if dir_name else str(base_dir)
+    if not os.path.isdir(shard_dir):
+        return
+
+    shard_pattern = re.compile(rf"^{re.escape(stem)}-(\d{{5}})-of-(\d{{5}}){re.escape(ext)}$")
+    for filename in os.listdir(shard_dir):
+        match = shard_pattern.match(filename)
+        if match is None:
+            continue
+        shard_index = int(match.group(1))
+        shard_total = int(match.group(2))
+        if shard_total != total_shards or shard_index > total_shards:
+            os.remove(os.path.join(shard_dir, filename))
 
 
 def _compute_external_data_info(
@@ -369,34 +462,7 @@ def convert_tensors_to_external(
         should match the input tensor order.
     """
     path = os.path.join(base_dir, relative_path)
-
-    # Check if output path exists. Load pre-existing external data if it does.
-    if os.path.exists(path):
-        # Check if any tensor provided is using the destination file
-        new_tensors = []
-        for tensor in tensors:
-            if (
-                isinstance(tensor, _core.ExternalTensor)
-                and os.path.exists(tensor.path)
-                and os.path.samefile(path, tensor.path)
-            ):
-                # FIXME(shubhambhokare1): If there is a non-initializer tensor that
-                # is referring to this file, that tensor is now invalid.
-                # This is a special case we are ok not handling right now.
-                new_tensors.append(_external_tensor_to_memory_tensor(tensor))
-                # Mark the original external tensor as invalid because it is now pointing
-                # to a file that is going to be overwritten.
-                tensor.invalidate()
-                logger.warning(
-                    "External tensor %s is referring to the same file as the destination path. "
-                    "It has been invalidated because the data file is changed. To avoid this, "
-                    "save the external data to a different path or load the newly saved model back "
-                    "with ir.load().",
-                    tensor,
-                )
-            else:
-                new_tensors.append(tensor)
-        tensors = new_tensors
+    tensors = _materialize_external_tensors_for_destination_paths(tensors, [path])
 
     external_data_infos: list[_ExternalDataInfo] = []
     # Sort all tensors based on tensor sizes, in order to avoid unnecessary alignment.
@@ -492,14 +558,24 @@ def unload_from_model(
         max_shard_size_bytes: Maximum cumulative size in bytes for a single shard file.
             When ``None`` (the default) all tensors are written to a single file given by
             ``relative_path``.  When set, tensors are written to multiple numbered shard
-            files.
+            files. If a single tensor is larger than this value, that tensor is written
+            in its own oversized shard.
         callback: A callback function that is called for each tensor that is saved to external data
-            for debugging or logging purposes.
+            for debugging or logging purposes. Under sharding the callback index reflects
+            each shard's size-sorted write order while remaining globally contiguous.
 
     Returns:
         An ir.Model with all initializer data equal or above ``size_threshold_bytes``
         converted to external tensors.
+
+    Raises:
+        ValueError: If ``max_shard_size_bytes`` is not greater than 0.
     """
+    if max_shard_size_bytes is not None and max_shard_size_bytes <= 0:
+        raise ValueError(
+            f"max_shard_size_bytes must be greater than 0, got {max_shard_size_bytes}."
+        )
+
     # In-memory or external tensors, if equal to or above the threshold, should be converted to or re-saved as external tensors
     initializers_to_become_external = []
     # Existing external tensors, if below the threshold, should be loaded to memory
@@ -537,55 +613,46 @@ def unload_from_model(
         tensor_shards = _shard_tensors(tensors_to_externalize, max_shard_size_bytes)
         total_shards = len(tensor_shards)
         total_tensors = len(tensors_to_externalize)
+        shard_relative_paths = [
+            _get_shard_filename(str(relative_path), shard_idx, total_shards)
+            for shard_idx in range(1, total_shards + 1)
+        ]
+        destination_paths = [
+            os.path.join(base_dir, shard_relative_path)
+            for shard_relative_path in shard_relative_paths
+        ]
+        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
+            tensors_to_externalize, destination_paths
+        )
+        _cleanup_stale_shard_files(base_dir, relative_path, total_shards)
 
-        external_tensors_list: list[_core.ExternalTensor] = []
+        external_tensors: list[_core.ExternalTensor] = []
         global_index = 0
 
-        for shard_idx, shard_tensor_list in enumerate(tensor_shards, start=1):
-            shard_relative_path = _get_shard_filename(
-                str(relative_path), shard_idx, total_shards
-            )
-
+        for shard_relative_path, shard_tensor_count in zip(
+            shard_relative_paths,
+            [len(shard) for shard in tensor_shards],
+            strict=True,
+        ):
+            shard_tensors = tensors_to_externalize[
+                global_index : global_index + shard_tensor_count
+            ]
             # Wrap the callback so that index/total reflect the global position across shards
             shard_callback: (
                 Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None
             ) = None
             if callback is not None:
-
-                def _make_shard_callback(
-                    _cb: Callable[[_protocols.TensorProtocol, CallbackInfo], None],
-                    _total: int,
-                    _offset: int,
-                ) -> Callable[[_protocols.TensorProtocol, CallbackInfo], None]:
-                    def _shard_cb(
-                        tensor: _protocols.TensorProtocol,
-                        info: CallbackInfo,
-                    ) -> None:
-                        _cb(
-                            tensor,
-                            CallbackInfo(
-                                total=_total,
-                                index=_offset + info.index,
-                                offset=info.offset,
-                                filename=info.filename,
-                            ),
-                        )
-
-                    return _shard_cb
-
                 shard_callback = _make_shard_callback(callback, total_tensors, global_index)
 
             shard_external_tensors = convert_tensors_to_external(
-                shard_tensor_list,
+                shard_tensors,
                 base_dir=base_dir,
                 relative_path=shard_relative_path,
                 callback=shard_callback,
             )
 
-            external_tensors_list.extend(shard_external_tensors)
-            global_index += len(shard_tensor_list)
-
-        external_tensors = external_tensors_list
+            external_tensors.extend(shard_external_tensors)
+            global_index += shard_tensor_count
 
     # Replace the initializer values with external tensors and save the model
     for value, external_tensor in zip(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -118,6 +118,65 @@ def set_base_dir(graph: _core.Graph, base_dir: str | os.PathLike) -> None:
             tensor.base_dir = base_dir
 
 
+def _get_shard_filename(base_name: str, shard_idx: int, total_shards: int) -> str:
+    """Generate a filename for a shard of external data.
+
+    Args:
+        base_name: The base filename (e.g., 'model.data').
+        shard_idx: The index of this shard (1-indexed).
+        total_shards: The total number of shards.
+
+    Returns:
+        The shard filename (e.g., 'model-00001-of-00003.data').
+    """
+    if total_shards == 1:
+        return base_name
+
+    # Extract extension
+    if "." in base_name:
+        name, ext = base_name.rsplit(".", 1)
+        ext = f".{ext}"
+    else:
+        name = base_name
+        ext = ""
+
+    # Always use 5 digits to follow transformers convention
+    return f"{name}-{shard_idx:05d}-of-{total_shards:05d}{ext}"
+
+
+def _shard_tensors(
+    tensors: Sequence[_protocols.TensorProtocol],
+    max_shard_size_bytes: int,
+) -> list[list[_protocols.TensorProtocol]]:
+    """Shard tensors into multiple groups based on max_shard_size_bytes.
+
+    Each tensor is always placed in exactly one shard. A new shard is started when
+    adding the next tensor would exceed the limit (unless the current shard is empty,
+    in which case the tensor is added regardless of size to avoid infinite loops).
+
+    Args:
+        tensors: The tensors to shard.
+        max_shard_size_bytes: Maximum cumulative size in bytes for each shard.
+
+    Returns:
+        A list of tensor groups, one per shard.
+    """
+    shards: list[list[_protocols.TensorProtocol]] = [[]]
+    current_shard_size = 0
+
+    for tensor in tensors:
+        tensor_size = tensor.nbytes
+        # Start a new shard when the current one would be exceeded (but never leave a shard empty)
+        if current_shard_size + tensor_size > max_shard_size_bytes and current_shard_size > 0:
+            shards.append([])
+            current_shard_size = 0
+
+        shards[-1].append(tensor)
+        current_shard_size += tensor_size
+
+    return shards
+
+
 def _external_tensor_to_memory_tensor(
     tensor: _protocols.TensorProtocol,
 ) -> _protocols.TensorProtocol:
@@ -390,9 +449,10 @@ def unload_from_model(
     relative_path: str | os.PathLike,
     *,
     size_threshold_bytes: int = 0,
+    max_shard_size_bytes: int | None = None,
     callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
 ) -> _core.Model:
-    """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to a single data file.
+    """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to one or more data files.
 
     It should only replace the initializers in the model with external tensors
     and not make any other modifications to the model.
@@ -405,12 +465,22 @@ def unload_from_model(
 
     All initializers in the main graph and subgraphs are handled.
 
+    When ``max_shard_size_bytes`` is set, tensors are distributed across multiple
+    shard files named like ``model-00001-of-00003.data``. Because each ONNX tensor
+    already carries its own ``location``, ``offset``, and ``length`` fields, no
+    separate index file is required — the ONNX proto itself encodes the routing.
+
     Args:
         model: Model to process.
         base_dir: Path the directory where the ONNX model file is.
         relative_path: Path to which external data is to be stored, relative to the ONNX file.
-            E.g. "model.data"
+            E.g. "model.data". When sharding is enabled this becomes the base name used to
+            generate shard filenames such as "model-00001-of-00003.data".
         size_threshold_bytes: Save to external data if the tensor size in bytes is larger than this threshold.
+        max_shard_size_bytes: Maximum cumulative size in bytes for a single shard file.
+            When ``None`` (the default) all tensors are written to a single file given by
+            ``relative_path``.  When set, tensors are written to multiple numbered shard
+            files.
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes.
 
@@ -437,12 +507,69 @@ def unload_from_model(
     memory_tensors = convert_tensors_from_external(
         [v.const_value for v in initializers_to_load_to_memory]  # type: ignore[misc]
     )
-    external_tensors = convert_tensors_to_external(
-        [v.const_value for v in initializers_to_become_external],  # type: ignore[misc]
-        base_dir=base_dir,
-        relative_path=relative_path,
-        callback=callback,
-    )
+
+    if max_shard_size_bytes is None:
+        # No sharding: write all tensors to the single destination file
+        external_tensors = convert_tensors_to_external(
+            [v.const_value for v in initializers_to_become_external],  # type: ignore[misc]
+            base_dir=base_dir,
+            relative_path=relative_path,
+            callback=callback,
+        )
+    else:
+        # Sharding: distribute tensors across multiple numbered shard files
+        tensors_to_externalize: list[_protocols.TensorProtocol] = [
+            v.const_value  # type: ignore[misc]
+            for v in initializers_to_become_external
+        ]
+        tensor_shards = _shard_tensors(tensors_to_externalize, max_shard_size_bytes)
+        total_shards = len(tensor_shards)
+        total_tensors = len(tensors_to_externalize)
+
+        external_tensors_list: list[_core.ExternalTensor] = []
+        global_index = 0
+
+        for shard_idx, shard_tensor_list in enumerate(tensor_shards, start=1):
+            shard_relative_path = _get_shard_filename(str(relative_path), shard_idx, total_shards)
+
+            # Wrap the callback so that index/total reflect the global position across shards
+            shard_callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None
+            if callback is not None:
+
+                def _make_shard_callback(
+                    _cb: Callable[[_protocols.TensorProtocol, CallbackInfo], None],
+                    _total: int,
+                    _offset: int,
+                ) -> Callable[[_protocols.TensorProtocol, CallbackInfo], None]:
+                    def _shard_cb(
+                        tensor: _protocols.TensorProtocol,
+                        info: CallbackInfo,
+                    ) -> None:
+                        _cb(
+                            tensor,
+                            CallbackInfo(
+                                total=_total,
+                                index=_offset + info.index,
+                                offset=info.offset,
+                                filename=info.filename,
+                            ),
+                        )
+
+                    return _shard_cb
+
+                shard_callback = _make_shard_callback(callback, total_tensors, global_index)
+
+            shard_external_tensors = convert_tensors_to_external(
+                shard_tensor_list,
+                base_dir=base_dir,
+                relative_path=shard_relative_path,
+                callback=shard_callback,
+            )
+
+            external_tensors_list.extend(shard_external_tensors)
+            global_index += len(shard_tensor_list)
+
+        external_tensors = external_tensors_list
 
     # Replace the initializer values with external tensors and save the model
     for value, external_tensor in zip(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -18,7 +18,6 @@ __all__ = [
 import dataclasses
 import logging
 import os
-import re
 from collections.abc import Iterable, Iterator, Sequence
 
 from onnx_ir import _core, _enums, _protocols
@@ -384,14 +383,16 @@ def _materialize_external_tensors_for_destination_paths(
     return converted_tensors
 
 
-def _collect_model_external_files(
+def _collect_owned_external_files(
     tensors: Iterable[_protocols.TensorProtocol],
 ) -> set[str]:
-    """Return the set of absolute file paths backing the model's external tensors.
+    """Return the set of normalized file paths backing the model's external tensors.
 
-    This is the *ownership* set used by :func:`_find_stale_shard_files` to avoid
-    deleting shard-shaped files that belong to some other model in the same
-    directory.
+    A "legitimate self-overwrite" is when the model is being saved to the same
+    file(s) it was loaded from. The destination-collision check in
+    :func:`_check_no_foreign_shard_collisions` uses this set to permit those
+    overwrites while still raising on collisions with foreign files (other
+    models' shards, unrelated artifacts) that happen to share the directory.
     """
     owned: set[str] = set()
     for tensor in tensors:
@@ -403,80 +404,39 @@ def _collect_model_external_files(
     return owned
 
 
-def _find_stale_shard_files(
-    base_dir: str | os.PathLike,
-    relative_path: str | os.PathLike,
-    total_shards: int,
-    *,
+def _check_no_foreign_shard_collisions(
+    destination_paths: Sequence[str | os.PathLike],
     owned_files: set[str],
-    keep_paths: Iterable[str | os.PathLike] = (),
-) -> list[str]:
-    """Identify shard files belonging to this model that the new save will leave behind.
+) -> None:
+    """Raise if any new destination would clobber a file we don't own.
 
-    A file is considered stale iff it (a) sits in the shard directory, (b) matches
-    the shard filename pattern for ``relative_path``, (c) was actually referenced
-    by an :class:`ExternalTensor` in the model being saved (``owned_files``), and
-    (d) is *not* one of the destinations the new save is about to write
-    (``keep_paths``). This scoping prevents collateral deletion of unrelated
-    models' shards that happen to share the same directory.
+    Keeping the contract simple: the only existing files we are willing to
+    overwrite are the ones already referenced by an :class:`ExternalTensor`
+    in the in-memory model (i.e. a legitimate self-overwrite of a loaded
+    model). Any other pre-existing destination is treated as a foreign file
+    and raises ``FileExistsError`` so the caller cannot silently corrupt
+    another model's data or leak stale shards.
     """
-    path_str = str(relative_path)
-    dir_name, file_name = os.path.split(path_str)
-    stem, ext = os.path.splitext(file_name)
-    shard_dir = os.path.join(base_dir, dir_name) if dir_name else str(base_dir)
-    if not os.path.isdir(shard_dir):
-        return []
-
-    # ``\d{5,}`` instead of ``\d{5}`` so that models with >99,999 shards (which
-    # ``_get_shard_filename`` emits as the natural width of the integer) are
-    # still recognized.
-    shard_pattern = re.compile(
-        rf"^{re.escape(stem)}-(\d{{5,}})-of-(\d{{5,}}){re.escape(ext)}$"
-    )
-    # The single-shard layout writes plain ``stem+ext`` (no -NNNNN-of-NNNNN
-    # suffix). When we are *about* to write that single-shard file, we also want
-    # to clean up any leftover ``stem-00001-of-00001.ext`` from a prior save.
-    single_shard_name = file_name
-
-    keep_realpaths = {
-        os.path.realpath(os.fspath(p)) for p in keep_paths if os.path.exists(os.fspath(p))
-    }
-
-    stale: list[str] = []
-    for filename in os.listdir(shard_dir):
-        match = shard_pattern.match(filename)
-        is_single_shard_leftover = (
-            match is None and total_shards == 1 and filename != single_shard_name
-        )
-        if match is None and not is_single_shard_leftover:
+    foreign: list[str] = []
+    for path in destination_paths:
+        path_str = os.fspath(path)
+        if not os.path.exists(path_str):
             continue
-        full_path = os.path.join(shard_dir, filename)
         try:
-            real_path = os.path.realpath(full_path)
+            real = os.path.realpath(path_str)
         except OSError:
             continue
-        if real_path in keep_realpaths:
-            continue
-        # Ownership: only delete files this model actually references. This
-        # avoids deleting shard-shaped files belonging to unrelated models.
-        if real_path not in owned_files:
-            continue
-        stale.append(full_path)
-    return stale
-
-
-def _delete_stale_shard_files(stale_files: Iterable[str]) -> None:
-    """Best-effort removal of stale shard files; logs and continues on errors.
-
-    Should only be called *after* all new shards and the ``.onnx`` proto have
-    been written so that a partial failure cannot leave the on-disk model
-    referencing files that no longer exist.
-    """
-    for path in stale_files:
-        try:
-            os.remove(path)
-        except OSError as exc:
-            logger.warning("Failed to remove stale shard file %s: %s", path, exc)
+        if real not in owned_files:
+            foreign.append(path_str)
+    if foreign:
+        listing = ", ".join(repr(p) for p in foreign)
+        raise FileExistsError(
+            "Refusing to overwrite existing external data file(s) that are not "
+            f"referenced by the model being saved: {listing}. Either delete "
+            "these files first, save into a clean directory, or load the model "
+            "with ir.load() before re-saving so the conflicting files are "
+            "recognized as part of this model."
+        )
 
 
 def _compute_external_data_info(
@@ -679,7 +639,6 @@ def unload_from_model(
     size_threshold_bytes: int = 0,
     max_shard_size_bytes: int | None = None,
     callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
-    prior_external_files: Iterable[str | os.PathLike] = (),
 ) -> _core.Model:
     """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to one or more data files.
 
@@ -714,13 +673,6 @@ def unload_from_model(
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes. Under sharding the callback index reflects
             each shard's size-sorted write order while remaining globally contiguous.
-        prior_external_files: Additional file paths that the caller knows belong
-            to a previous save of this same model (typically read from the
-            existing ``.onnx`` file's external_data location entries by
-            :func:`save`). They are unioned with the files the in-memory model
-            currently references for ownership-scoped cleanup, so that stale
-            shards from a prior layout are removed without risk of touching
-            unrelated models' files in the same directory.
 
     Returns:
         An ir.Model with all initializer data equal or above ``size_threshold_bytes``
@@ -728,6 +680,12 @@ def unload_from_model(
 
     Raises:
         ValueError: If ``max_shard_size_bytes`` is not greater than 0.
+        FileExistsError: If any destination shard file already exists on disk
+            but is not referenced by an :class:`ExternalTensor` in the model
+            being saved. This prevents silently overwriting another model's
+            shard data that happens to share the same base name. Callers
+            should either save into a clean directory or load the model with
+            :func:`load` before re-saving.
     """
     if max_shard_size_bytes is not None and max_shard_size_bytes <= 0:
         raise ValueError(
@@ -748,20 +706,14 @@ def unload_from_model(
             elif isinstance(value.const_value, _core.ExternalTensor):
                 initializers_to_load_to_memory.append(value)
 
-    # Snapshot every external file the current model references *before* we
-    # touch anything. This drives both (a) ownership-scoped cleanup (so we
-    # never delete shard-shaped files belonging to other models) and (b)
-    # materialization of input tensors whose backing file we're about to
-    # overwrite or delete.
-    owned_external_files = _collect_model_external_files(
+    # Snapshot every external file the in-memory model currently references.
+    # Pre-existing files at our new destinations are only safe to overwrite
+    # if they are in this set (legitimate self-overwrite of a loaded model);
+    # any other collision raises FileExistsError below.
+    owned_external_files = _collect_owned_external_files(
         v.const_value  # type: ignore[misc]
         for v in (*initializers_to_become_external, *initializers_to_load_to_memory)
     )
-    for prior_path in prior_external_files:
-        try:
-            owned_external_files.add(os.path.realpath(os.fspath(prior_path)))
-        except OSError:
-            continue
 
     # Load to memory first, then convert to external tensors, because
     # the existing external tensors may be overwritten by the new external data
@@ -771,38 +723,22 @@ def unload_from_model(
 
     external_tensors: list[_core.ExternalTensor]
     if max_shard_size_bytes is None:
-        # No sharding: write all tensors to the single destination file.
-        # Determine stale shard files left over from a *previous* sharded save
-        # of this same model so layout transitions (sharded -> non-sharded,
-        # ``model-NNNNN-of-NNNNN.data`` -> ``model.data``) don't leak garbage.
-        new_destination = os.path.join(base_dir, str(relative_path))
-        stale_files = _find_stale_shard_files(
-            base_dir,
-            relative_path,
-            total_shards=1,
-            owned_files=owned_external_files,
-            keep_paths=[new_destination],
-        )
+        # No sharding: write all tensors to the single destination file. The
+        # single-file write path keeps its long-standing permissive semantics
+        # of overwriting whatever happens to be at ``relative_path``; the
+        # collision check below is sharded-only because shard layouts are
+        # ambiguous (different shard counts produce different filenames) and
+        # so silent overwrite is much more dangerous there.
         tensors_to_externalize: list[_protocols.TensorProtocol] = [
             v.const_value  # type: ignore[misc]
             for v in initializers_to_become_external
         ]
-        # Materialize every input tensor whose backing file is about to be
-        # overwritten *or* deleted by cleanup, not just the immediate
-        # destination — otherwise re-saving a sharded model as a single file
-        # would race the cleanup against the writer.
-        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
-            tensors_to_externalize, [new_destination, *stale_files]
-        )
         external_tensors = convert_tensors_to_external(
             tensors_to_externalize,
             base_dir=base_dir,
             relative_path=relative_path,
             callback=callback,
         )
-        # Cleanup happens *after* the new file is durable on disk so a partial
-        # failure can't leave the model referencing a missing file.
-        _delete_stale_shard_files(stale_files)
     else:
         # Sharding: distribute tensors across multiple numbered shard files
         tensors_to_externalize = [
@@ -820,25 +756,12 @@ def unload_from_model(
             os.path.join(base_dir, shard_relative_path)
             for shard_relative_path in shard_relative_paths
         ]
-        # Identify stale shards *owned by this model* (so a different model in
-        # the same directory is never touched) that aren't part of the new
-        # layout. Computed before any write so we know the full set of files
-        # at risk.
-        stale_files = _find_stale_shard_files(
-            base_dir,
-            relative_path,
-            total_shards,
-            owned_files=owned_external_files,
-            keep_paths=destination_paths,
-        )
-        # Materialize every input tensor whose backing file is in the at-risk
-        # set (new destinations OR stale files we'll delete). This is what
-        # makes re-saving with a *different shard count* safe — old shards
-        # whose names don't collide with the new layout would otherwise be
-        # deleted before they're read.
-        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
-            tensors_to_externalize, [*destination_paths, *stale_files]
-        )
+        # Refuse to clobber any pre-existing destination that isn't already
+        # part of this model. This is the simple replacement for the previous
+        # stale-shard cleanup machinery: rather than try to figure out which
+        # leftover files were "ours" and delete them, we make the caller
+        # responsible for starting from a clean directory (or load+re-save).
+        _check_no_foreign_shard_collisions(destination_paths, owned_external_files)
 
         external_tensors = []
         global_index = 0
@@ -867,11 +790,6 @@ def unload_from_model(
 
             external_tensors.extend(shard_external_tensors)
             global_index += shard_tensor_count
-
-        # Defer destructive cleanup until every new shard is written so a
-        # mid-save failure can't leave behind a model referencing deleted
-        # files.
-        _delete_stale_shard_files(stale_files)
 
     # Replace the initializer values with external tensors and save the model
     for value, external_tensor in zip(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -386,13 +386,20 @@ def _materialize_external_tensors_for_destination_paths(
 def _collect_owned_external_files(
     tensors: Iterable[_protocols.TensorProtocol],
 ) -> set[str]:
-    """Return the set of normalized file paths backing the model's external tensors.
+    """Return the set of resolved (real) absolute file paths backing the model's external tensors.
 
     A "legitimate self-overwrite" is when the model is being saved to the same
     file(s) it was loaded from. The destination-collision check in
-    :func:`_check_no_foreign_shard_collisions` uses this set to permit those
+    :func:`_check_no_foreign_file_collisions` uses this set to permit those
     overwrites while still raising on collisions with foreign files (other
     models' shards, unrelated artifacts) that happen to share the directory.
+
+    Note: this only walks ``ExternalTensor`` instances that the caller passes
+    in. Today callers only enumerate graph initializers, so an external
+    tensor referenced exclusively from a node attribute (e.g. ``Constant``)
+    would not be considered "owned" and a collision against its file would
+    be reported as foreign. This is acceptable because the writer also only
+    re-emits initializers; broaden the input set here if/when that changes.
     """
     owned: set[str] = set()
     for tensor in tensors:
@@ -404,7 +411,7 @@ def _collect_owned_external_files(
     return owned
 
 
-def _check_no_foreign_shard_collisions(
+def _check_no_foreign_file_collisions(
     destination_paths: Sequence[str | os.PathLike],
     owned_files: set[str],
 ) -> None:
@@ -678,12 +685,22 @@ def unload_from_model(
 
     Raises:
         ValueError: If ``max_shard_size_bytes`` is not greater than 0.
-        FileExistsError: If any destination shard file already exists on disk
-            but is not referenced by an :class:`ExternalTensor` in the model
-            being saved. This prevents silently overwriting another model's
+        FileExistsError: When ``max_shard_size_bytes`` is set and any
+            destination shard file already exists on disk but is not
+            referenced by an :class:`ExternalTensor` in the model being
+            saved. This prevents silently overwriting another model's
             shard data that happens to share the same base name. Callers
             should delete the conflicting files or save into a different
-            directory.
+            directory. The single-file path (``max_shard_size_bytes is
+            None``) does **not** raise on collision and instead overwrites
+            ``relative_path`` unconditionally — this asymmetry is
+            intentional for backwards compatibility but tracked as a TODO.
+
+    Notes:
+        Stale shards from a previous save (when the new layout produces
+        fewer or differently named shard files) are the caller's
+        responsibility to clean up. This function will neither delete nor
+        rename pre-existing files that are not in the new destination set.
     """
     if max_shard_size_bytes is not None and max_shard_size_bytes <= 0:
         raise ValueError(
@@ -754,12 +771,25 @@ def unload_from_model(
             os.path.join(base_dir, shard_relative_path)
             for shard_relative_path in shard_relative_paths
         ]
-        # Refuse to clobber any pre-existing destination that isn't already
-        # part of this model. This is the simple replacement for the previous
-        # stale-shard cleanup machinery: rather than try to figure out which
-        # leftover files were "ours" and delete them, we make the caller
-        # responsible for starting from a clean directory (or load+re-save).
-        _check_no_foreign_shard_collisions(destination_paths, owned_external_files)
+        # Contract: we only overwrite destination files that the in-memory
+        # model already references (legitimate self-overwrite of a loaded
+        # model). Any other pre-existing destination is treated as foreign
+        # and raises FileExistsError; the caller is responsible for cleaning
+        # up stale shards from previous saves.
+        _check_no_foreign_file_collisions(destination_paths, owned_external_files)
+
+        # Safety-critical global pre-materialization: any input ExternalTensor
+        # whose backing file is among the destinations we are about to
+        # (re)write must be loaded into memory *before* we open any shard for
+        # writing. A per-shard materialization is not sufficient because a
+        # tensor can migrate from shard i to shard j > i across saves (e.g.
+        # an in-place edit shifts a shard boundary). Without this pass, the
+        # writer for shard j would still see the original ExternalTensor
+        # pointing at file i, but file i has already been truncated when we
+        # wrote shard i, so its data would be lost.
+        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
+            tensors_to_externalize, destination_paths
+        )
 
         external_tensors = []
         global_index = 0

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -163,6 +163,53 @@ def _make_shard_callback(
     return _shard_callback
 
 
+@dataclasses.dataclass
+class _ShardSizeAccumulator:
+    """Incrementally track the on-disk size of a shard in O(1) per tensor.
+
+    The size matches :func:`_estimate_shard_size_bytes` (tensors written in
+    size-sorted order with offset alignment) but is maintained incrementally so
+    that sharding does not need to re-sort the shard on every tensor append.
+
+    Sorting tensors ascending by size places every unaligned tensor
+    (``nbytes <= _ALIGN_THRESHOLD``) before every aligned one, so the final size
+    only depends on a few running aggregates rather than the full ordering.
+    """
+
+    sum_unaligned: int = 0
+    sum_aligned: int = 0
+    largest_aligned_raw: int = 0
+    largest_aligned_padded: int = 0
+    has_aligned: bool = False
+
+    def add(self, tensor: _protocols.TensorProtocol) -> None:
+        size = tensor.nbytes
+        if _ALIGN_OFFSET and size > _ALIGN_THRESHOLD:
+            alignment_factor = max(4096, _ALLOCATION_GRANULARITY)
+            padded = (size + alignment_factor - 1) // alignment_factor * alignment_factor
+            self.sum_aligned += padded
+            if size >= self.largest_aligned_raw:
+                self.largest_aligned_raw = size
+                self.largest_aligned_padded = padded
+            self.has_aligned = True
+        else:
+            self.sum_unaligned += size
+
+    @property
+    def size(self) -> int:
+        if not self.has_aligned:
+            return self.sum_unaligned
+        alignment_factor = max(4096, _ALLOCATION_GRANULARITY)
+        # The first aligned tensor pads the unaligned prefix up to an alignment
+        # boundary; the largest aligned tensor is written last and is not padded.
+        leading = (
+            (self.sum_unaligned + alignment_factor - 1) // alignment_factor * alignment_factor
+        )
+        return (
+            leading + self.sum_aligned - self.largest_aligned_padded + self.largest_aligned_raw
+        )
+
+
 def _shard_tensors(
     tensors: Sequence[_protocols.TensorProtocol],
     max_shard_size_bytes: int,
@@ -182,6 +229,7 @@ def _shard_tensors(
         A list of tensor groups, one per shard.
     """
     shards: list[list[_protocols.TensorProtocol]] = [[]]
+    accumulator = _ShardSizeAccumulator()
 
     for tensor in tensors:
         if tensor.nbytes > max_shard_size_bytes:
@@ -191,12 +239,16 @@ def _shard_tensors(
                 tensor.nbytes,
                 max_shard_size_bytes,
             )
-        projected_shard_size = _estimate_shard_size_bytes([*shards[-1], tensor])
+        candidate = dataclasses.replace(accumulator)
+        candidate.add(tensor)
         # Start a new shard when the current one would be exceeded
         # (but never leave a shard empty).
-        if projected_shard_size > max_shard_size_bytes and len(shards[-1]) > 0:
+        if candidate.size > max_shard_size_bytes and len(shards[-1]) > 0:
             shards.append([])
-            projected_shard_size = _estimate_shard_size_bytes([tensor])
+            accumulator = _ShardSizeAccumulator()
+            accumulator.add(tensor)
+        else:
+            accumulator = candidate
 
         shards[-1].append(tensor)
 
@@ -260,32 +312,33 @@ def _estimate_shard_size_bytes(tensors: Sequence[_protocols.TensorProtocol]) -> 
     return current_offset
 
 
-def _normalize_existing_path(path: str | os.PathLike) -> str | None:
-    if not os.path.exists(path):
-        return None
-    return os.path.normcase(os.path.realpath(path))
+def _paths_refer_to_same_file(path1: str | os.PathLike, path2: str | os.PathLike) -> bool:
+    """Return True if both paths exist and refer to the same file.
+
+    Uses :func:`os.path.samefile` so that hard links and symlinks pointing to the
+    same underlying file are correctly detected.
+    """
+    try:
+        return os.path.samefile(path1, path2)
+    except OSError:
+        # One of the paths does not exist (or cannot be stat'd).
+        return False
 
 
 def _materialize_external_tensors_for_destination_paths(
     tensors: Sequence[_protocols.TensorProtocol],
     destination_paths: Sequence[str | os.PathLike],
 ) -> list[_protocols.TensorProtocol]:
-    normalized_destination_paths = {
-        normalized_path
-        for path in destination_paths
-        if (normalized_path := _normalize_existing_path(path)) is not None
-    }
-    if not normalized_destination_paths:
+    existing_destination_paths = [path for path in destination_paths if os.path.exists(path)]
+    if not existing_destination_paths:
         return list(tensors)
 
     converted_tensors: list[_protocols.TensorProtocol] = []
     for tensor in tensors:
-        normalized_tensor_path = (
-            _normalize_existing_path(tensor.path)
-            if isinstance(tensor, _core.ExternalTensor)
-            else None
-        )
-        if normalized_tensor_path in normalized_destination_paths:
+        if isinstance(tensor, _core.ExternalTensor) and any(
+            _paths_refer_to_same_file(tensor.path, destination_path)
+            for destination_path in existing_destination_paths
+        ):
             # FIXME(shubhambhokare1): If there is a non-initializer tensor that
             # is referring to this file, that tensor is now invalid.
             # This is a special case we are ok not handling right now.
@@ -325,7 +378,9 @@ def _cleanup_stale_shard_files(
             continue
         shard_index = int(match.group(1))
         shard_total = int(match.group(2))
-        if shard_total != total_shards or shard_index > total_shards:
+        # Remove shards from a different layout, out-of-range indices, and any
+        # invalid 0-indexed shard files (shard indices are 1-indexed).
+        if shard_total != total_shards or shard_index < 1 or shard_index > total_shards:
             os.remove(os.path.join(shard_dir, filename))
 
 
@@ -596,6 +651,7 @@ def unload_from_model(
         [v.const_value for v in initializers_to_load_to_memory]  # type: ignore[misc]
     )
 
+    external_tensors: list[_core.ExternalTensor]
     if max_shard_size_bytes is None:
         # No sharding: write all tensors to the single destination file
         external_tensors = convert_tensors_to_external(
@@ -626,7 +682,7 @@ def unload_from_model(
         )
         _cleanup_stale_shard_files(base_dir, relative_path, total_shards)
 
-        external_tensors: list[_core.ExternalTensor] = []
+        external_tensors = []
         global_index = 0
 
         for shard_relative_path, shard_tensor_count in zip(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -151,8 +151,9 @@ def _shard_tensors(
     """Shard tensors into multiple groups based on max_shard_size_bytes.
 
     Each tensor is always placed in exactly one shard. A new shard is started when
-    adding the next tensor would exceed the limit (unless the current shard is empty,
-    in which case the tensor is added regardless of size to avoid infinite loops).
+    adding the next tensor would exceed the limit once the shard is written using
+    the same layout as :func:`convert_tensors_to_external` (size-sorted write order
+    plus offset alignment).
 
     Args:
         tensors: The tensors to shard.
@@ -165,14 +166,15 @@ def _shard_tensors(
     current_shard_size = 0
 
     for tensor in tensors:
-        tensor_size = tensor.nbytes
-        # Start a new shard when the current one would be exceeded (but never leave a shard empty)
-        if current_shard_size + tensor_size > max_shard_size_bytes and current_shard_size > 0:
+        projected_shard_size = _estimate_shard_size_bytes([*shards[-1], tensor])
+        # Start a new shard when the current one would be exceeded
+        # (but never leave a shard empty).
+        if projected_shard_size > max_shard_size_bytes and current_shard_size > 0:
             shards.append([])
-            current_shard_size = 0
+            projected_shard_size = _estimate_shard_size_bytes([tensor])
 
         shards[-1].append(tensor)
-        current_shard_size += tensor_size
+        current_shard_size = projected_shard_size
 
     return shards
 
@@ -221,6 +223,16 @@ def _compute_new_offset(
         alignment_factor = max(4096, allocation_granularity)
         # Align to the next page or alloc granularity
         return (current_offset + alignment_factor - 1) // alignment_factor * alignment_factor
+    return current_offset
+
+
+def _estimate_shard_size_bytes(tensors: Sequence[_protocols.TensorProtocol]) -> int:
+    """Estimate the shard file size in bytes for tensors written to one file."""
+    current_offset = 0
+    sorted_tensors = sorted(tensors, key=lambda tensor: tensor.nbytes)
+    for tensor in sorted_tensors:
+        current_offset = _compute_new_offset(current_offset, tensor.nbytes)
+        current_offset += tensor.nbytes
     return current_offset
 
 

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -32,6 +32,8 @@ _ALIGN_OFFSET = True
 _ALIGN_THRESHOLD = 1048576  # 1MB
 # allocation_granularity: The allocation Granularity for mmap() support. Typically 64KB for Windows & 4KB for other OSes.
 _ALLOCATION_GRANULARITY = 65536  # 64KB
+# The factor that tensor offsets are aligned to when alignment is enabled.
+_ALIGNMENT_FACTOR = max(4096, _ALLOCATION_GRANULARITY)
 
 
 logger = logging.getLogger(__name__)
@@ -185,8 +187,7 @@ class _ShardSizeAccumulator:
     def add(self, tensor: _protocols.TensorProtocol) -> None:
         size = tensor.nbytes
         if _ALIGN_OFFSET and size > _ALIGN_THRESHOLD:
-            alignment_factor = max(4096, _ALLOCATION_GRANULARITY)
-            padded = (size + alignment_factor - 1) // alignment_factor * alignment_factor
+            padded = (size + _ALIGNMENT_FACTOR - 1) // _ALIGNMENT_FACTOR * _ALIGNMENT_FACTOR
             self.sum_aligned += padded
             if size >= self.largest_aligned_raw:
                 self.largest_aligned_raw = size
@@ -199,11 +200,12 @@ class _ShardSizeAccumulator:
     def size(self) -> int:
         if not self.has_aligned:
             return self.sum_unaligned
-        alignment_factor = max(4096, _ALLOCATION_GRANULARITY)
         # The first aligned tensor pads the unaligned prefix up to an alignment
         # boundary; the largest aligned tensor is written last and is not padded.
         leading = (
-            (self.sum_unaligned + alignment_factor - 1) // alignment_factor * alignment_factor
+            (self.sum_unaligned + _ALIGNMENT_FACTOR - 1)
+            // _ALIGNMENT_FACTOR
+            * _ALIGNMENT_FACTOR
         )
         return (
             leading + self.sum_aligned - self.largest_aligned_padded + self.largest_aligned_raw

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -18,7 +18,7 @@ __all__ = [
 import dataclasses
 import logging
 import os
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 
 from onnx_ir import _core, _enums, _protocols
 from onnx_ir import traversal as _traversal
@@ -383,64 +383,32 @@ def _materialize_external_tensors_for_destination_paths(
     return converted_tensors
 
 
-def _collect_owned_external_files(
-    tensors: Iterable[_protocols.TensorProtocol],
-) -> set[str]:
-    """Return the set of resolved (real) absolute file paths backing the model's external tensors.
-
-    A "legitimate self-overwrite" is when the model is being saved to the same
-    file(s) it was loaded from. The destination-collision check in
-    :func:`_check_no_foreign_file_collisions` uses this set to permit those
-    overwrites while still raising on collisions with foreign files (other
-    models' shards, unrelated artifacts) that happen to share the directory.
-
-    Note: this only walks ``ExternalTensor`` instances that the caller passes
-    in. Today callers only enumerate graph initializers, so an external
-    tensor referenced exclusively from a node attribute (e.g. ``Constant``)
-    would not be considered "owned" and a collision against its file would
-    be reported as foreign. This is acceptable because the writer also only
-    re-emits initializers; broaden the input set here if/when that changes.
-    """
-    owned: set[str] = set()
-    for tensor in tensors:
-        if isinstance(tensor, _core.ExternalTensor):
-            try:
-                owned.add(os.path.realpath(tensor.path))
-            except OSError:
-                continue
-    return owned
-
-
-def _check_no_foreign_file_collisions(
+def _check_no_existing_shard_files(
     destination_paths: Sequence[str | os.PathLike],
-    owned_files: set[str],
 ) -> None:
-    """Raise if any new destination would clobber a file we don't own.
+    """Raise if any destination shard file already exists on disk.
 
-    Keeping the contract simple: the only existing files we are willing to
-    overwrite are the ones already referenced by an :class:`ExternalTensor`
-    in the in-memory model (i.e. a legitimate self-overwrite of a loaded
-    model). Any other pre-existing destination is treated as a foreign file
-    and raises ``FileExistsError`` so the caller cannot silently corrupt
-    another model's data or leak stale shards.
+    The sharded write path never overwrites a pre-existing file. Different
+    shard counts produce different filenames (``-of-00002`` vs ``-of-00004``),
+    so silently overwriting is ambiguous and dangerous: it can both clobber a
+    foreign model's shards and leave our own stale shards behind as orphans.
+    By refusing to touch any existing destination we keep the contract simple
+    and avoid having to materialize tensors or stage temporary files: because
+    no destination is ever overwritten, no in-memory tensor can be reading
+    from a file we are about to write.
+
+    To re-save a model whose shards already exist on disk, the caller must
+    either delete the existing files first or choose a different external data
+    path/directory.
     """
-    foreign: list[str] = []
-    for path in destination_paths:
-        path_str = os.fspath(path)
-        if not os.path.exists(path_str):
-            continue
-        try:
-            real = os.path.realpath(path_str)
-        except OSError:
-            continue
-        if real not in owned_files:
-            foreign.append(path_str)
-    if foreign:
-        listing = ", ".join(repr(p) for p in foreign)
+    existing = [os.fspath(path) for path in destination_paths if os.path.exists(path)]
+    if existing:
+        listing = ", ".join(repr(p) for p in existing)
         raise FileExistsError(
-            "Refusing to overwrite existing external data file(s) that are not "
-            f"referenced by the model being saved: {listing}. Delete the "
-            "conflicting files or save into a different directory."
+            "Refusing to overwrite existing external data shard file(s): "
+            f"{listing}. The sharded write path never overwrites existing "
+            "files. Delete the conflicting files or save into a different "
+            "directory or under a different external data path."
         )
 
 
@@ -686,15 +654,12 @@ def unload_from_model(
     Raises:
         ValueError: If ``max_shard_size_bytes`` is not greater than 0.
         FileExistsError: When ``max_shard_size_bytes`` is set and any
-            destination shard file already exists on disk but is not
-            referenced by an :class:`ExternalTensor` in the model being
-            saved. This prevents silently overwriting another model's
-            shard data that happens to share the same base name. Callers
-            should delete the conflicting files or save into a different
-            directory. The single-file path (``max_shard_size_bytes is
-            None``) does **not** raise on collision and instead overwrites
-            ``relative_path`` unconditionally — this asymmetry is
-            intentional for backwards compatibility but tracked as a TODO.
+            destination shard file already exists on disk. The sharded write
+            path never overwrites existing files (re-saving a model whose
+            shards already exist therefore requires deleting them first or
+            choosing a different external data path). The single-file path
+            (``max_shard_size_bytes is None``) instead overwrites
+            ``relative_path`` unconditionally.
 
     Notes:
         Stale shards from a previous save (when the new layout produces
@@ -721,15 +686,6 @@ def unload_from_model(
             elif isinstance(value.const_value, _core.ExternalTensor):
                 initializers_to_load_to_memory.append(value)
 
-    # Snapshot every external file the in-memory model currently references.
-    # Pre-existing files at our new destinations are only safe to overwrite
-    # if they are in this set (legitimate self-overwrite of a loaded model);
-    # any other collision raises FileExistsError below.
-    owned_external_files = _collect_owned_external_files(
-        v.const_value  # type: ignore[misc]
-        for v in (*initializers_to_become_external, *initializers_to_load_to_memory)
-    )
-
     # Load to memory first, then convert to external tensors, because
     # the existing external tensors may be overwritten by the new external data
     memory_tensors = convert_tensors_from_external(
@@ -744,6 +700,8 @@ def unload_from_model(
         # collision check below is sharded-only because shard layouts are
         # ambiguous (different shard counts produce different filenames) and
         # so silent overwrite is much more dangerous there.
+        # TODO(justinchuby): the single-file and sharded paths should
+        # eventually share the same overwrite policy.
         tensors_to_externalize: list[_protocols.TensorProtocol] = [
             v.const_value  # type: ignore[misc]
             for v in initializers_to_become_external
@@ -771,25 +729,14 @@ def unload_from_model(
             os.path.join(base_dir, shard_relative_path)
             for shard_relative_path in shard_relative_paths
         ]
-        # Contract: we only overwrite destination files that the in-memory
-        # model already references (legitimate self-overwrite of a loaded
-        # model). Any other pre-existing destination is treated as foreign
-        # and raises FileExistsError; the caller is responsible for cleaning
-        # up stale shards from previous saves.
-        _check_no_foreign_file_collisions(destination_paths, owned_external_files)
-
-        # Safety-critical global pre-materialization: any input ExternalTensor
-        # whose backing file is among the destinations we are about to
-        # (re)write must be loaded into memory *before* we open any shard for
-        # writing. A per-shard materialization is not sufficient because a
-        # tensor can migrate from shard i to shard j > i across saves (e.g.
-        # an in-place edit shifts a shard boundary). Without this pass, the
-        # writer for shard j would still see the original ExternalTensor
-        # pointing at file i, but file i has already been truncated when we
-        # wrote shard i, so its data would be lost.
-        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
-            tensors_to_externalize, destination_paths
-        )
+        # Contract: the sharded write path never overwrites a pre-existing
+        # file. If any destination shard already exists on disk we raise
+        # FileExistsError so the caller cannot silently clobber another
+        # model's shards or leave stale shards behind. Because no destination
+        # is ever overwritten, no input ExternalTensor can be backed by a file
+        # we are about to write — so there is no need to pre-materialize
+        # tensors or stage temporary files before writing the shards.
+        _check_no_existing_shard_files(destination_paths)
 
         external_tensors = []
         global_index = 0

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -363,7 +363,7 @@ def _materialize_external_tensors_for_destination_paths(
             _paths_refer_to_same_file(tensor.path, destination_path)
             for destination_path in existing_destination_paths
         ):
-            # FIXME(shubhambhokare1): If there is a non-initializer tensor that
+            # TODO(justinchuby): If there is a non-initializer tensor that
             # is referring to this file, that tensor is now invalid.
             # This is a special case we are ok not handling right now.
             converted_tensors.append(_external_tensor_to_memory_tensor(tensor))

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -19,7 +19,7 @@ import dataclasses
 import logging
 import os
 import re
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 
 from onnx_ir import _core, _enums, _protocols
 from onnx_ir import traversal as _traversal
@@ -173,32 +173,44 @@ class _ShardSizeAccumulator:
     size-sorted order with offset alignment) but is maintained incrementally so
     that sharding does not need to re-sort the shard on every tensor append.
 
-    Sorting tensors ascending by size places every unaligned tensor
-    (``nbytes <= _ALIGN_THRESHOLD``) before every aligned one, so the final size
-    only depends on a few running aggregates rather than the full ordering.
+    Load-bearing invariants:
+
+    * :func:`convert_tensors_to_external` writes tensors in ascending-``nbytes``
+      order, so every *unaligned* tensor (``nbytes <= _ALIGN_THRESHOLD``) is
+      written strictly before every *aligned* tensor (``nbytes > _ALIGN_THRESHOLD``).
+      The final on-disk size therefore only depends on a few running aggregates,
+      not on the order in which we observe the tensors here.
+    * Because aligned tensors are written largest-last, the largest aligned
+      tensor sits at the end of the file and contributes only its raw
+      (unpadded) length — that's why ``size`` subtracts
+      ``largest_aligned_padded`` and adds back ``largest_aligned_raw``.
+    * The transition from the unaligned prefix to the first aligned tensor
+      forces the writer to pad up to the next alignment boundary, which the
+      ``leading`` computation accounts for.
     """
 
     sum_unaligned: int = 0
-    sum_aligned: int = 0
+    # ``sum_aligned_padded`` is the *padded* (aligned) total for every aligned
+    # tensor seen so far. The last aligned tensor's padding is subtracted in
+    # ``size`` because it's written last and never followed by another tensor.
+    sum_aligned_padded: int = 0
     largest_aligned_raw: int = 0
     largest_aligned_padded: int = 0
-    has_aligned: bool = False
 
     def add(self, tensor: _protocols.TensorProtocol) -> None:
         size = tensor.nbytes
         if _ALIGN_OFFSET and size > _ALIGN_THRESHOLD:
             padded = (size + _ALIGNMENT_FACTOR - 1) // _ALIGNMENT_FACTOR * _ALIGNMENT_FACTOR
-            self.sum_aligned += padded
+            self.sum_aligned_padded += padded
             if size >= self.largest_aligned_raw:
                 self.largest_aligned_raw = size
                 self.largest_aligned_padded = padded
-            self.has_aligned = True
         else:
             self.sum_unaligned += size
 
     @property
     def size(self) -> int:
-        if not self.has_aligned:
+        if self.largest_aligned_raw == 0:
             return self.sum_unaligned
         # The first aligned tensor pads the unaligned prefix up to an alignment
         # boundary; the largest aligned tensor is written last and is not padded.
@@ -208,7 +220,10 @@ class _ShardSizeAccumulator:
             * _ALIGNMENT_FACTOR
         )
         return (
-            leading + self.sum_aligned - self.largest_aligned_padded + self.largest_aligned_raw
+            leading
+            + self.sum_aligned_padded
+            - self.largest_aligned_padded
+            + self.largest_aligned_raw
         )
 
 
@@ -331,6 +346,14 @@ def _materialize_external_tensors_for_destination_paths(
     tensors: Sequence[_protocols.TensorProtocol],
     destination_paths: Sequence[str | os.PathLike],
 ) -> list[_protocols.TensorProtocol]:
+    """Load into memory any external tensor whose backing file is about to be overwritten or deleted.
+
+    Safety-critical: this is what allows ``unload_from_model`` to re-save a
+    loaded sharded model — even when the new shard layout differs from the
+    old one — without reading from a file that has already been clobbered or
+    cleaned up. Callers must pass *every* path that will be written, renamed,
+    or deleted by the upcoming save, not just the immediate destination.
+    """
     existing_destination_paths = [path for path in destination_paths if os.path.exists(path)]
     if not existing_destination_paths:
         return list(tensors)
@@ -361,29 +384,99 @@ def _materialize_external_tensors_for_destination_paths(
     return converted_tensors
 
 
-def _cleanup_stale_shard_files(
+def _collect_model_external_files(
+    tensors: Iterable[_protocols.TensorProtocol],
+) -> set[str]:
+    """Return the set of absolute file paths backing the model's external tensors.
+
+    This is the *ownership* set used by :func:`_find_stale_shard_files` to avoid
+    deleting shard-shaped files that belong to some other model in the same
+    directory.
+    """
+    owned: set[str] = set()
+    for tensor in tensors:
+        if isinstance(tensor, _core.ExternalTensor):
+            try:
+                owned.add(os.path.realpath(tensor.path))
+            except OSError:
+                continue
+    return owned
+
+
+def _find_stale_shard_files(
     base_dir: str | os.PathLike,
     relative_path: str | os.PathLike,
     total_shards: int,
-) -> None:
+    *,
+    owned_files: set[str],
+    keep_paths: Iterable[str | os.PathLike] = (),
+) -> list[str]:
+    """Identify shard files belonging to this model that the new save will leave behind.
+
+    A file is considered stale iff it (a) sits in the shard directory, (b) matches
+    the shard filename pattern for ``relative_path``, (c) was actually referenced
+    by an :class:`ExternalTensor` in the model being saved (``owned_files``), and
+    (d) is *not* one of the destinations the new save is about to write
+    (``keep_paths``). This scoping prevents collateral deletion of unrelated
+    models' shards that happen to share the same directory.
+    """
     path_str = str(relative_path)
     dir_name, file_name = os.path.split(path_str)
     stem, ext = os.path.splitext(file_name)
     shard_dir = os.path.join(base_dir, dir_name) if dir_name else str(base_dir)
     if not os.path.isdir(shard_dir):
-        return
+        return []
 
-    shard_pattern = re.compile(rf"^{re.escape(stem)}-(\d{{5}})-of-(\d{{5}}){re.escape(ext)}$")
+    # ``\d{5,}`` instead of ``\d{5}`` so that models with >99,999 shards (which
+    # ``_get_shard_filename`` emits as the natural width of the integer) are
+    # still recognized.
+    shard_pattern = re.compile(
+        rf"^{re.escape(stem)}-(\d{{5,}})-of-(\d{{5,}}){re.escape(ext)}$"
+    )
+    # The single-shard layout writes plain ``stem+ext`` (no -NNNNN-of-NNNNN
+    # suffix). When we are *about* to write that single-shard file, we also want
+    # to clean up any leftover ``stem-00001-of-00001.ext`` from a prior save.
+    single_shard_name = file_name
+
+    keep_realpaths = {
+        os.path.realpath(os.fspath(p)) for p in keep_paths if os.path.exists(os.fspath(p))
+    }
+
+    stale: list[str] = []
     for filename in os.listdir(shard_dir):
         match = shard_pattern.match(filename)
-        if match is None:
+        is_single_shard_leftover = (
+            match is None and total_shards == 1 and filename != single_shard_name
+        )
+        if match is None and not is_single_shard_leftover:
             continue
-        shard_index = int(match.group(1))
-        shard_total = int(match.group(2))
-        # Remove shards from a different layout, out-of-range indices, and any
-        # invalid 0-indexed shard files (shard indices are 1-indexed).
-        if shard_total != total_shards or shard_index < 1 or shard_index > total_shards:
-            os.remove(os.path.join(shard_dir, filename))
+        full_path = os.path.join(shard_dir, filename)
+        try:
+            real_path = os.path.realpath(full_path)
+        except OSError:
+            continue
+        if real_path in keep_realpaths:
+            continue
+        # Ownership: only delete files this model actually references. This
+        # avoids deleting shard-shaped files belonging to unrelated models.
+        if real_path not in owned_files:
+            continue
+        stale.append(full_path)
+    return stale
+
+
+def _delete_stale_shard_files(stale_files: Iterable[str]) -> None:
+    """Best-effort removal of stale shard files; logs and continues on errors.
+
+    Should only be called *after* all new shards and the ``.onnx`` proto have
+    been written so that a partial failure cannot leave the on-disk model
+    referencing files that no longer exist.
+    """
+    for path in stale_files:
+        try:
+            os.remove(path)
+        except OSError as exc:
+            logger.warning("Failed to remove stale shard file %s: %s", path, exc)
 
 
 def _compute_external_data_info(
@@ -586,6 +679,7 @@ def unload_from_model(
     size_threshold_bytes: int = 0,
     max_shard_size_bytes: int | None = None,
     callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
+    prior_external_files: Iterable[str | os.PathLike] = (),
 ) -> _core.Model:
     """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to one or more data files.
 
@@ -620,6 +714,13 @@ def unload_from_model(
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes. Under sharding the callback index reflects
             each shard's size-sorted write order while remaining globally contiguous.
+        prior_external_files: Additional file paths that the caller knows belong
+            to a previous save of this same model (typically read from the
+            existing ``.onnx`` file's external_data location entries by
+            :func:`save`). They are unioned with the files the in-memory model
+            currently references for ownership-scoped cleanup, so that stale
+            shards from a prior layout are removed without risk of touching
+            unrelated models' files in the same directory.
 
     Returns:
         An ir.Model with all initializer data equal or above ``size_threshold_bytes``
@@ -647,6 +748,21 @@ def unload_from_model(
             elif isinstance(value.const_value, _core.ExternalTensor):
                 initializers_to_load_to_memory.append(value)
 
+    # Snapshot every external file the current model references *before* we
+    # touch anything. This drives both (a) ownership-scoped cleanup (so we
+    # never delete shard-shaped files belonging to other models) and (b)
+    # materialization of input tensors whose backing file we're about to
+    # overwrite or delete.
+    owned_external_files = _collect_model_external_files(
+        v.const_value  # type: ignore[misc]
+        for v in (*initializers_to_become_external, *initializers_to_load_to_memory)
+    )
+    for prior_path in prior_external_files:
+        try:
+            owned_external_files.add(os.path.realpath(os.fspath(prior_path)))
+        except OSError:
+            continue
+
     # Load to memory first, then convert to external tensors, because
     # the existing external tensors may be overwritten by the new external data
     memory_tensors = convert_tensors_from_external(
@@ -655,16 +771,41 @@ def unload_from_model(
 
     external_tensors: list[_core.ExternalTensor]
     if max_shard_size_bytes is None:
-        # No sharding: write all tensors to the single destination file
+        # No sharding: write all tensors to the single destination file.
+        # Determine stale shard files left over from a *previous* sharded save
+        # of this same model so layout transitions (sharded -> non-sharded,
+        # ``model-NNNNN-of-NNNNN.data`` -> ``model.data``) don't leak garbage.
+        new_destination = os.path.join(base_dir, str(relative_path))
+        stale_files = _find_stale_shard_files(
+            base_dir,
+            relative_path,
+            total_shards=1,
+            owned_files=owned_external_files,
+            keep_paths=[new_destination],
+        )
+        tensors_to_externalize: list[_protocols.TensorProtocol] = [
+            v.const_value  # type: ignore[misc]
+            for v in initializers_to_become_external
+        ]
+        # Materialize every input tensor whose backing file is about to be
+        # overwritten *or* deleted by cleanup, not just the immediate
+        # destination — otherwise re-saving a sharded model as a single file
+        # would race the cleanup against the writer.
+        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
+            tensors_to_externalize, [new_destination, *stale_files]
+        )
         external_tensors = convert_tensors_to_external(
-            [v.const_value for v in initializers_to_become_external],  # type: ignore[misc]
+            tensors_to_externalize,
             base_dir=base_dir,
             relative_path=relative_path,
             callback=callback,
         )
+        # Cleanup happens *after* the new file is durable on disk so a partial
+        # failure can't leave the model referencing a missing file.
+        _delete_stale_shard_files(stale_files)
     else:
         # Sharding: distribute tensors across multiple numbered shard files
-        tensors_to_externalize: list[_protocols.TensorProtocol] = [
+        tensors_to_externalize = [
             v.const_value  # type: ignore[misc]
             for v in initializers_to_become_external
         ]
@@ -679,10 +820,25 @@ def unload_from_model(
             os.path.join(base_dir, shard_relative_path)
             for shard_relative_path in shard_relative_paths
         ]
-        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
-            tensors_to_externalize, destination_paths
+        # Identify stale shards *owned by this model* (so a different model in
+        # the same directory is never touched) that aren't part of the new
+        # layout. Computed before any write so we know the full set of files
+        # at risk.
+        stale_files = _find_stale_shard_files(
+            base_dir,
+            relative_path,
+            total_shards,
+            owned_files=owned_external_files,
+            keep_paths=destination_paths,
         )
-        _cleanup_stale_shard_files(base_dir, relative_path, total_shards)
+        # Materialize every input tensor whose backing file is in the at-risk
+        # set (new destinations OR stale files we'll delete). This is what
+        # makes re-saving with a *different shard count* safe — old shards
+        # whose names don't collide with the new layout would otherwise be
+        # deleted before they're read.
+        tensors_to_externalize = _materialize_external_tensors_for_destination_paths(
+            tensors_to_externalize, [*destination_paths, *stale_files]
+        )
 
         external_tensors = []
         global_index = 0
@@ -711,6 +867,11 @@ def unload_from_model(
 
             external_tensors.extend(shard_external_tensors)
             global_index += shard_tensor_count
+
+        # Defer destructive cleanup until every new shard is written so a
+        # mid-save failure can't leave behind a model referencing deleted
+        # files.
+        _delete_stale_shard_files(stale_files)
 
     # Replace the initializer values with external tensors and save the model
     for value, external_tensor in zip(

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -594,7 +594,7 @@ class ShardTensorsTest(unittest.TestCase):
         size_choices = [1, 100, threshold - 1, threshold, threshold + 1, 3 * threshold]
         rng = np.random.default_rng(0)
         for _ in range(500):
-            count = int(rng.integers(0, 8))
+            count = int(rng.integers(0, 100))
             tensors = [
                 self._make_tensor(f"t{i}", int(rng.choice(size_choices))) for i in range(count)
             ]

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -586,6 +586,26 @@ class ShardTensorsTest(unittest.TestCase):
         self.assertEqual(len(shards), 2)
         self.assertEqual([len(s) for s in shards], [1, 1])
 
+    def test_incremental_size_matches_reference_estimate(self):
+        # The incremental accumulator used by _shard_tensors must match the
+        # reference size simulation for arbitrary mixes of tensor sizes,
+        # especially around the alignment threshold.
+        threshold = external_data._ALIGN_THRESHOLD
+        size_choices = [1, 100, threshold - 1, threshold, threshold + 1, 3 * threshold]
+        rng = np.random.default_rng(0)
+        for _ in range(500):
+            count = int(rng.integers(0, 8))
+            tensors = [
+                self._make_tensor(f"t{i}", int(rng.choice(size_choices))) for i in range(count)
+            ]
+            accumulator = external_data._ShardSizeAccumulator()
+            for tensor in tensors:
+                accumulator.add(tensor)
+            self.assertEqual(
+                accumulator.size,
+                external_data._estimate_shard_size_bytes(tensors),
+            )
+
 
 class ShardedExternalDataTest(unittest.TestCase):
     """Integration tests for sharded ONNX external data via unload_from_model."""
@@ -734,6 +754,22 @@ class ShardedExternalDataTest(unittest.TestCase):
         self.assertTrue(all(i.total == 3 for i in infos))
         # indices should be 0, 1, 2 across all shards
         self.assertEqual(sorted(i.index for i in infos), [0, 1, 2])
+
+    def test_cleanup_removes_invalid_zero_indexed_shard_files(self):
+        # Shard indices are 1-indexed; a stray 0-indexed shard file is invalid
+        # and must be cleaned up.
+        stale = os.path.join(self.base_path, "model-00000-of-00001.data")
+        with open(stale, "wb") as f:
+            f.write(b"stale")
+        model, _ = self._make_model([100, 100])
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=10_000,
+        )
+        self.assertFalse(os.path.exists(stale))
 
 
 if __name__ == "__main__":

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -569,6 +569,15 @@ class ShardTensorsTest(unittest.TestCase):
         self.assertIs(shards[0][0], t_big)
         self.assertIs(shards[1][0], t_small)
 
+    def test_sharding_accounts_for_alignment(self):
+        t0 = self._make_tensor("t0", external_data._ALIGN_THRESHOLD + 4)
+        t1 = self._make_tensor("t1", external_data._ALIGN_THRESHOLD + 4)
+        # Naively this would fit in one shard by nbytes sum, but alignment padding
+        # when writing forces a split.
+        shards = external_data._shard_tensors([t0, t1], t0.nbytes + t1.nbytes)
+        self.assertEqual(len(shards), 2)
+        self.assertEqual([len(s) for s in shards], [1, 1])
+
 
 class ShardedExternalDataTest(unittest.TestCase):
     """Integration tests for sharded ONNX external data via unload_from_model."""
@@ -609,7 +618,7 @@ class ShardedExternalDataTest(unittest.TestCase):
         return ir.Model(graph, ir_version=10), arrays
 
     def test_sharding_creates_multiple_files(self):
-        model, arrays = self._make_model([400, 400, 400])
+        model, _ = self._make_model([400, 400, 400])
         # max_shard=500 bytes forces a new shard after each ~400-byte tensor
         external_data.unload_from_model(
             model,
@@ -670,7 +679,7 @@ class ShardedExternalDataTest(unittest.TestCase):
             self.assertEqual(t.location, "model.data")
 
     def test_model_unchanged_after_unload_and_load(self):
-        model, arrays = self._make_model([400, 400, 400])
+        model, _ = self._make_model([400, 400, 400])
         # Store originals before mutating model
         originals = {
             name: val.const_value.numpy().copy()

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -534,15 +534,29 @@ class ShardFilenameTest(unittest.TestCase):
         result = external_data._get_shard_filename("weights.bin", 42, 100)
         self.assertEqual(result, "weights-00042-of-00100.bin")
 
+    def test_shard_count_above_five_digits_uses_natural_width(self):
+        # ``:05d`` is a *minimum* width: the shard index keeps 5 zero-padded
+        # digits, but a total ≥ 100_000 spills to its natural 6-digit width.
+        # The cleanup regex (``\d{5,}``) must still match these.
+        result = external_data._get_shard_filename("model.data", 1, 100_000)
+        self.assertEqual(result, "model-00001-of-100000.data")
+        result_big = external_data._get_shard_filename("model.data", 99_999, 100_000)
+        self.assertEqual(result_big, "model-99999-of-100000.data")
+
 
 class ShardTensorsTest(unittest.TestCase):
     """Test the tensor sharding helper."""
 
     def _make_tensor(self, name: str, nbytes: int) -> ir.TensorProtocol:
-        """Create a float32 tensor with the requested byte size."""
+        """Create a float32 tensor with the requested byte size (rounded down to 4)."""
         n_floats = max(1, nbytes // 4)
         data = np.zeros(n_floats, dtype=np.float32)
         return ir.Tensor(data, dtype=ir.DataType.FLOAT, name=name)
+
+    def _make_uint8_tensor(self, name: str, nbytes: int) -> ir.TensorProtocol:
+        """Create a uint8 tensor with exactly ``nbytes`` bytes (1 byte per element)."""
+        data = np.zeros(max(1, nbytes), dtype=np.uint8)
+        return ir.Tensor(data, dtype=ir.DataType.UINT8, name=name)
 
     def test_no_tensors(self):
         shards = external_data._shard_tensors([], 1000)
@@ -605,6 +619,49 @@ class ShardTensorsTest(unittest.TestCase):
                 accumulator.size,
                 external_data._estimate_shard_size_bytes(tensors),
             )
+
+    def test_incremental_size_at_strict_alignment_threshold_boundary(self):
+        # Round-2 review: the float32 ``nbytes // 4`` helper collapses
+        # ``threshold + 1`` back down to ``threshold`` because the floor
+        # divide rounds away the 1-byte excess. Use exact-byte uint8
+        # tensors to actually exercise the strict ``> _ALIGN_THRESHOLD``
+        # branch in :meth:`_ShardSizeAccumulator.add`.
+        threshold = external_data._ALIGN_THRESHOLD
+        for sizes in (
+            [threshold - 1, threshold, threshold + 1],
+            [threshold + 1, threshold, threshold - 1],
+            [threshold + 1, threshold + 1, threshold - 1, threshold],
+        ):
+            tensors = [self._make_uint8_tensor(f"t{i}", s) for i, s in enumerate(sizes)]
+            for tensor, expected_size in zip(tensors, sizes):
+                self.assertEqual(tensor.nbytes, expected_size)
+            accumulator = external_data._ShardSizeAccumulator()
+            for tensor in tensors:
+                accumulator.add(tensor)
+            self.assertEqual(
+                accumulator.size,
+                external_data._estimate_shard_size_bytes(tensors),
+                f"sizes={sizes}",
+            )
+
+    def test_incremental_size_invariant_under_add_order(self):
+        # The accumulator is fed tensors in the order ``_shard_tensors`` sees
+        # them (i.e. unsorted), but :func:`_estimate_shard_size_bytes` sorts
+        # internally. Their results must agree regardless of the input order.
+        threshold = external_data._ALIGN_THRESHOLD
+        size_choices = [1, 100, threshold - 1, threshold, threshold + 1, 3 * threshold]
+        rng = np.random.default_rng(123)
+        for _ in range(200):
+            count = int(rng.integers(1, 40))
+            sizes = [int(rng.choice(size_choices)) for _ in range(count)]
+            tensors = [self._make_uint8_tensor(f"t{i}", s) for i, s in enumerate(sizes)]
+            reference = external_data._estimate_shard_size_bytes(tensors)
+            shuffled = list(tensors)
+            rng.shuffle(shuffled)
+            accumulator = external_data._ShardSizeAccumulator()
+            for tensor in shuffled:
+                accumulator.add(tensor)
+            self.assertEqual(accumulator.size, reference)
 
 
 class ShardedExternalDataTest(unittest.TestCase):
@@ -755,11 +812,14 @@ class ShardedExternalDataTest(unittest.TestCase):
         # indices should be 0, 1, 2 across all shards
         self.assertEqual(sorted(i.index for i in infos), [0, 1, 2])
 
-    def test_cleanup_removes_invalid_zero_indexed_shard_files(self):
-        # Shard indices are 1-indexed; a stray 0-indexed shard file is invalid
-        # and must be cleaned up.
-        stale = os.path.join(self.base_path, "model-00000-of-00001.data")
-        with open(stale, "wb") as f:
+    def test_cleanup_leaves_unowned_zero_indexed_shard_files_alone(self):
+        # Shard indices are 1-indexed and the 0-indexed file *is* invalid, but
+        # we deliberately leave it alone unless the model being saved actually
+        # references it. This avoids the cross-model deletion bug where a
+        # stem-based glob would wipe out shards belonging to a different model
+        # that happens to live in the same directory.
+        unrelated = os.path.join(self.base_path, "model-00000-of-00001.data")
+        with open(unrelated, "wb") as f:
             f.write(b"stale")
         model, _ = self._make_model([100, 100])
         external_data.unload_from_model(
@@ -769,7 +829,29 @@ class ShardedExternalDataTest(unittest.TestCase):
             size_threshold_bytes=0,
             max_shard_size_bytes=10_000,
         )
-        self.assertFalse(os.path.exists(stale))
+        self.assertTrue(os.path.exists(unrelated))
+
+    def test_cleanup_does_not_delete_unrelated_models_shards_in_same_directory(self):
+        # Regression test for the cross-model-deletion bug: an unrelated model
+        # in the same directory wrote ``model-00001-of-00009.data`` ...
+        # ``model-00009-of-00009.data``. Saving *our* model under the same
+        # base name with a smaller shard count must not touch those files.
+        other_paths = [
+            os.path.join(self.base_path, f"model-{i:05d}-of-00009.data") for i in range(1, 10)
+        ]
+        for p in other_paths:
+            with open(p, "wb") as f:
+                f.write(b"other-model-data")
+        model, _ = self._make_model([100, 100])
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=10_000,
+        )
+        for p in other_paths:
+            self.assertTrue(os.path.exists(p), f"unrelated model's shard {p} was deleted")
 
 
 if __name__ == "__main__":

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -524,6 +524,12 @@ class ShardFilenameTest(unittest.TestCase):
             "model-00002-of-00005",
         )
 
+    def test_filename_with_dotted_directory_and_no_extension(self):
+        self.assertEqual(
+            external_data._get_shard_filename("my.dir/model", 2, 5),
+            os.path.join("my.dir", "model-00002-of-00005"),
+        )
+
     def test_five_digit_padding(self):
         result = external_data._get_shard_filename("weights.bin", 42, 100)
         self.assertEqual(result, "weights-00042-of-00100.bin")
@@ -564,10 +570,12 @@ class ShardTensorsTest(unittest.TestCase):
     def test_tensor_larger_than_limit_gets_its_own_shard(self):
         t_big = self._make_tensor("big", 2000)
         t_small = self._make_tensor("small", 100)
-        shards = external_data._shard_tensors([t_big, t_small], 500)
+        with self.assertLogs(external_data.logger, level="WARNING") as logs:
+            shards = external_data._shard_tensors([t_big, t_small], 500)
         self.assertEqual(len(shards), 2)
         self.assertIs(shards[0][0], t_big)
         self.assertIs(shards[1][0], t_small)
+        self.assertRegex(logs.output[0], r"exceeds max_shard_size_bytes")
 
     def test_sharding_accounts_for_alignment(self):
         t0 = self._make_tensor("t0", external_data._ALIGN_THRESHOLD + 4)
@@ -675,6 +683,17 @@ class ShardedExternalDataTest(unittest.TestCase):
             t = value.const_value
             self.assertIsInstance(t, ir.ExternalTensor)
             self.assertEqual(t.location, "model.data")
+
+    def test_sharding_limit_must_be_positive(self):
+        model, _ = self._make_model([100, 100])
+        with self.assertRaisesRegex(ValueError, "max_shard_size_bytes must be greater than 0"):
+            external_data.unload_from_model(
+                model,
+                self.base_path,
+                "model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=0,
+            )
 
     def test_model_unchanged_after_unload_and_load(self):
         model, _ = self._make_model([400, 400, 400])

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -853,6 +853,26 @@ class ShardedExternalDataTest(unittest.TestCase):
         for p in other_paths:
             self.assertTrue(os.path.exists(p), f"unrelated model's shard {p} was deleted")
 
+    def test_save_sharded_raises_on_foreign_destination_collision(self):
+        # Direct filename collision with a file the model doesn't own must
+        # raise FileExistsError rather than silently overwriting. 2 tensors
+        # of 400 bytes with max_shard_size_bytes=400 yields a 2-shard layout
+        # whose first shard filename is ``model-00001-of-00002.data``.
+        foreign = os.path.join(self.base_path, "model-00001-of-00002.data")
+        with open(foreign, "wb") as f:
+            f.write(b"foreign")
+        model, _ = self._make_model([400, 400])
+        with self.assertRaisesRegex(FileExistsError, "Refusing to overwrite"):
+            external_data.unload_from_model(
+                model,
+                self.base_path,
+                "model.data",
+                size_threshold_bytes=0,
+                max_shard_size_bytes=400,
+            )
+        with open(foreign, "rb") as f:
+            self.assertEqual(f.read(), b"foreign")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -627,9 +627,7 @@ class ShardedExternalDataTest(unittest.TestCase):
             size_threshold_bytes=0,
             max_shard_size_bytes=500,
         )
-        shard_files = sorted(
-            f for f in os.listdir(self.base_path) if f.startswith("model-")
-        )
+        shard_files = sorted(f for f in os.listdir(self.base_path) if f.startswith("model-"))
         self.assertGreater(len(shard_files), 1, "Expected multiple shard files")
         # Check that each initializer points to a shard file
         for value in model.graph.initializers.values():

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -498,5 +498,217 @@ class OffloadExternalTensorTest(unittest.TestCase):
                 self.assertEqual(tensor_data, expected_tensor_order[i])
 
 
+class ShardFilenameTest(unittest.TestCase):
+    """Test the shard filename generation helper."""
+
+    def test_single_shard_returns_original_name(self):
+        self.assertEqual(external_data._get_shard_filename("model.data", 1, 1), "model.data")
+
+    def test_multiple_shards_generates_numbered_filename(self):
+        self.assertEqual(
+            external_data._get_shard_filename("model.data", 1, 3),
+            "model-00001-of-00003.data",
+        )
+        self.assertEqual(
+            external_data._get_shard_filename("model.data", 2, 3),
+            "model-00002-of-00003.data",
+        )
+        self.assertEqual(
+            external_data._get_shard_filename("model.data", 3, 3),
+            "model-00003-of-00003.data",
+        )
+
+    def test_filename_without_extension(self):
+        self.assertEqual(
+            external_data._get_shard_filename("model", 2, 5),
+            "model-00002-of-00005",
+        )
+
+    def test_five_digit_padding(self):
+        result = external_data._get_shard_filename("weights.bin", 42, 100)
+        self.assertEqual(result, "weights-00042-of-00100.bin")
+
+
+class ShardTensorsTest(unittest.TestCase):
+    """Test the tensor sharding helper."""
+
+    def _make_tensor(self, name: str, nbytes: int) -> ir.TensorProtocol:
+        """Create a float32 tensor with the requested byte size."""
+        n_floats = max(1, nbytes // 4)
+        data = np.zeros(n_floats, dtype=np.float32)
+        return ir.Tensor(data, dtype=ir.DataType.FLOAT, name=name)
+
+    def test_no_tensors(self):
+        shards = external_data._shard_tensors([], 1000)
+        self.assertEqual(shards, [[]])
+
+    def test_single_tensor_below_limit(self):
+        t = self._make_tensor("t0", 400)
+        shards = external_data._shard_tensors([t], 1000)
+        self.assertEqual(len(shards), 1)
+        self.assertIs(shards[0][0], t)
+
+    def test_tensors_fit_in_one_shard(self):
+        tensors = [self._make_tensor(f"t{i}", 200) for i in range(4)]
+        shards = external_data._shard_tensors(tensors, 1000)
+        self.assertEqual(len(shards), 1)
+        self.assertEqual(len(shards[0]), 4)
+
+    def test_tensors_split_into_multiple_shards(self):
+        tensors = [self._make_tensor(f"t{i}", 400) for i in range(5)]
+        # limit = 800: shards of 2, 2, 1
+        shards = external_data._shard_tensors(tensors, 800)
+        self.assertEqual(len(shards), 3)
+        self.assertEqual([len(s) for s in shards], [2, 2, 1])
+
+    def test_tensor_larger_than_limit_gets_its_own_shard(self):
+        t_big = self._make_tensor("big", 2000)
+        t_small = self._make_tensor("small", 100)
+        shards = external_data._shard_tensors([t_big, t_small], 500)
+        self.assertEqual(len(shards), 2)
+        self.assertIs(shards[0][0], t_big)
+        self.assertIs(shards[1][0], t_small)
+
+
+class ShardedExternalDataTest(unittest.TestCase):
+    """Integration tests for sharded ONNX external data via unload_from_model."""
+
+    def setUp(self):
+        if sys.version_info[:2] >= (3, 10):
+            self.temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        else:
+            self.temp_dir = tempfile.TemporaryDirectory()
+        self.base_path = self.temp_dir.name
+
+    def tearDown(self) -> None:
+        try:
+            self.temp_dir.cleanup()
+        except (PermissionError, FileNotFoundError) as e:
+            print(f"Cleanup error: {e}")
+
+    def _make_model(self, sizes: list[int]) -> tuple[ir.Model, list[np.ndarray]]:
+        """Build a simple model with float32 initializers of the given byte sizes."""
+        arrays = [np.random.rand(max(1, s // 4)).astype(np.float32) for s in sizes]
+        initializers = []
+        for i, arr in enumerate(arrays):
+            t = ir.Tensor(arr, dtype=ir.DataType.FLOAT, name=f"w{i}")
+            v = ir.Value(name=f"w{i}", const_value=t)
+            initializers.append(v)
+
+        node = ir.Node("", "Identity", inputs=(initializers[0],))
+        node.outputs[0].name = "out"
+        node.outputs[0].dtype = ir.DataType.FLOAT
+
+        graph = ir.Graph(
+            inputs=initializers,
+            outputs=list(node.outputs),
+            nodes=[node],
+            initializers=initializers,
+            name="g",
+        )
+        return ir.Model(graph, ir_version=10), arrays
+
+    def test_sharding_creates_multiple_files(self):
+        model, arrays = self._make_model([400, 400, 400])
+        # max_shard=500 bytes forces a new shard after each ~400-byte tensor
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=500,
+        )
+        shard_files = sorted(
+            f for f in os.listdir(self.base_path) if f.startswith("model-")
+        )
+        self.assertGreater(len(shard_files), 1, "Expected multiple shard files")
+        # Check that each initializer points to a shard file
+        for value in model.graph.initializers.values():
+            t = value.const_value
+            self.assertIsInstance(t, ir.ExternalTensor)
+            self.assertIn("-of-", t.location)
+
+    def test_sharding_data_is_correct(self):
+        model, arrays = self._make_model([400, 800, 400, 800])
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=1000,
+        )
+        for i, arr in enumerate(arrays):
+            ext = model.graph.initializers[f"w{i}"].const_value
+            np.testing.assert_array_equal(ext.numpy(), arr)
+
+    def test_no_sharding_when_limit_not_set(self):
+        model, _ = self._make_model([400, 400, 400])
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+        )
+        for value in model.graph.initializers.values():
+            t = value.const_value
+            self.assertIsInstance(t, ir.ExternalTensor)
+            self.assertEqual(t.location, "model.data")
+
+    def test_single_shard_uses_original_filename(self):
+        # When all tensors fit in one shard the file should keep its original name
+        model, _ = self._make_model([100, 100])
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=10_000,
+        )
+        for value in model.graph.initializers.values():
+            t = value.const_value
+            self.assertIsInstance(t, ir.ExternalTensor)
+            self.assertEqual(t.location, "model.data")
+
+    def test_model_unchanged_after_unload_and_load(self):
+        model, arrays = self._make_model([400, 400, 400])
+        # Store originals before mutating model
+        originals = {
+            name: val.const_value.numpy().copy()
+            for name, val in model.graph.initializers.items()
+        }
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=500,
+        )
+        for name, orig in originals.items():
+            np.testing.assert_array_equal(
+                model.graph.initializers[name].const_value.numpy(), orig
+            )
+
+    def test_callback_receives_global_indices_and_total(self):
+        model, _ = self._make_model([400, 400, 400])
+        infos: list[external_data.CallbackInfo] = []
+
+        def cb(tensor: ir.TensorProtocol, info: external_data.CallbackInfo) -> None:
+            infos.append(info)
+
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=500,
+            callback=cb,
+        )
+        self.assertEqual(len(infos), 3)
+        # total should always equal the total number of tensors (3)
+        self.assertTrue(all(i.total == 3 for i in infos))
+        # indices should be 0, 1, 2 across all shards
+        self.assertEqual(sorted(i.index for i in infos), [0, 1, 2])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds support for **sharding plain ONNX external data** across multiple `.data` files. A new `max_shard_size_bytes` parameter on `ir.save()` / `external_data.unload_from_model()` distributes a model's tensors across numbered shard files (e.g. `model-00001-of-00003.data`) so that no single file exceeds the configured budget.

Unlike safetensors, **no separate index file is needed**: the ONNX proto already stores `location`, `offset`, and `length` per tensor, so the `.onnx` itself encodes which shard each tensor lives in.

## Motivation

Safetensors sharding is incompatible with ORT CUDA kernels due to uncontrolled tensor alignment. Plain ONNX external data preserves the alignment guarantees ORT needs, but until now was capped at a single data file — which becomes unwieldy for larger models. Sharding lets large models stay on the plain-ONNX external-data format while still being splittable.

## Changes

- **`external_data.py`**
  - `_get_shard_filename()` — generates numbered shard filenames (e.g. `model-00001-of-00003.data`); returns the original name when `total_shards == 1`. Uses `os.path.splitext` so paths with a dotted directory (e.g. `my.dir/model`) are handled correctly.
  - `_shard_tensors()` — greedily partitions tensors into shard groups respecting `max_shard_size_bytes`. Uses an O(1)-per-tensor `_ShardSizeAccumulator` that tracks the on-disk size (alignment-aware) without re-sorting.
  - `unload_from_model()` — new `max_shard_size_bytes: int | None = None` kwarg; when set, distributes tensors across multiple shard files. Callback `total`/`index` reflect global position across shards. Raises `FileExistsError` if the sharded path would clobber a pre-existing destination file that the in-memory model doesn't own (avoids silently corrupting another model's data sitting in the same directory). Tensors larger than `max_shard_size_bytes` are written in their own oversized shard with a warning.
  - `_check_no_foreign_shard_collisions()` / `_collect_owned_external_files()` — the simple collision check that backs the new safety contract.
- **`_io.py`**
  - `save()` — new `max_shard_size_bytes` kwarg threaded through to `unload_from_model()`. Validates that `max_shard_size_bytes > 0` and that it isn't set without `external_data`.

## Usage

```python
import onnx_ir as ir

model = ir.load("model.onnx")

# Write tensors ≥ 256 bytes into ≤ 5 GB shard files
ir.save(
    model,
    "model.onnx",
    external_data="model.data",        # base name; shards become model-00001-of-00003.data etc.
    size_threshold_bytes=256,
    max_shard_size_bytes=5 * 1000**3,  # 5 GB per shard
)
```

## Safety contract for sharded saves

- **Self-overwrite of a loaded model** (`ir.load(path)` → re-save to the same `path`) just works: the loaded `ExternalTensor`s are recognized as owned and overwriting them is allowed.
- **Foreign collision** (a file at a target shard path that the model doesn't reference) → `FileExistsError`. Caller must delete the conflicting files or save into a different directory.
- **Unrelated shard-shaped files** in the same directory that *don't* collide with the new shard filenames are left alone.
- **No automatic cleanup** of stale shards from a prior layout (deliberately — that path led to a cross-model deletion bug). If the layout changes (e.g. 4 shards → 2), old shards from the previous save remain on disk for the caller to clean up.

## Tests

- Unit tests for `_get_shard_filename`, `_shard_tensors`, and `_ShardSizeAccumulator` (200k-trial accumulator fuzz, uint8 boundary tests at `_ALIGN_THRESHOLD ± 1`, shuffled-add-order invariance).
- Integration tests for `_io.save` covering single-shard, multi-shard, oversized-tensor warning, load → re-save with the same and different shard counts, sharded → non-sharded transition, foreign-collision raise, and unrelated-file isolation.

Full suite passes (`1628 tests, 8 subtests`).