### PR TITLE
Support sparse tensors

### DIFF
--- a/docs/tensors.md
+++ b/docs/tensors.md
@@ -79,7 +79,15 @@ Use {py:class}`onnx_ir.StringTensor <onnx_ir.StringTensor>` to create a string t
 
 ### Sparse Tensor
 
-Sparse tensors are not yet supported, but they are on our roadmap.
+Use {py:class}`onnx_ir.SparseTensor <onnx_ir.SparseTensor>` to create and work with sparse tensors in COO
+(coordinate) format, following the ONNX ``SparseTensorProto`` specification.
+
+A sparse tensor stores only the non-zero values and their indices, along with the dense shape. It can be:
+
+- Deserialized from an ``onnx.SparseTensorProto`` using {py:func}`onnx_ir.serde.deserialize_sparse_tensor <onnx_ir.serde.deserialize_sparse_tensor>`.
+- Serialized to an ``onnx.SparseTensorProto`` using {py:func}`onnx_ir.serde.serialize_sparse_tensor <onnx_ir.serde.serialize_sparse_tensor>`.
+- Used as a sparse initializer by setting ``value.const_value = sparse_tensor`` for a graph value registered as an initializer.
+- Used in node attributes via {py:func}`onnx_ir.AttrSparseTensor <onnx_ir.AttrSparseTensor>` and {py:func}`onnx_ir.AttrSparseTensors <onnx_ir.AttrSparseTensors>`.
 
 ## From `TensorProto`s and back
 

--- a/docs/tensors.md
+++ b/docs/tensors.md
@@ -84,9 +84,10 @@ Use {py:class}`onnx_ir.SparseTensor <onnx_ir.SparseTensor>` to create and work w
 
 A sparse tensor stores only the non-zero values and their indices, along with the dense shape. It can be:
 
+- Constructed from a ``scipy.sparse`` array using {py:meth}`onnx_ir.SparseTensor.from_scipy_sparse <onnx_ir.SparseTensor.from_scipy_sparse>`.
 - Deserialized from an ``onnx.SparseTensorProto`` using {py:func}`onnx_ir.serde.deserialize_sparse_tensor <onnx_ir.serde.deserialize_sparse_tensor>`.
 - Serialized to an ``onnx.SparseTensorProto`` using {py:func}`onnx_ir.serde.serialize_sparse_tensor <onnx_ir.serde.serialize_sparse_tensor>`.
-- Used as a sparse initializer by setting ``value.const_value = sparse_tensor`` for a graph value registered as an initializer.
+- Used as a sparse initializer by setting ``value.const_sparse_value = sparse_tensor`` for a graph value registered as an initializer.
 - Used in node attributes via {py:func}`onnx_ir.AttrSparseTensor <onnx_ir.AttrSparseTensor>` and {py:func}`onnx_ir.AttrSparseTensors <onnx_ir.AttrSparseTensors>`.
 
 ## From `TensorProto`s and back

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,6 +30,7 @@ COMMON_TEST_DEPENDENCIES = (
     "ml-dtypes",
     "onnxruntime",
     "safetensors",
+    "scipy",
 )
 ONNX = "onnx==1.18"
 ONNXSCRIPT = "onnxscript"

--- a/src/onnx_ir/__init__.py
+++ b/src/onnx_ir/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     # IR classes
     "Tensor",
     "ExternalTensor",
+    "SparseTensor",
     "StringTensor",
     "LazyTensor",
     "PackedTensor",
@@ -139,6 +140,7 @@ from onnx_ir._core import (
     RefAttr,
     SequenceType,
     Shape,
+    SparseTensor,
     SparseTensorType,
     StringTensor,
     SymbolicDim,

--- a/src/onnx_ir/_convenience/_constructors.py
+++ b/src/onnx_ir/_convenience/_constructors.py
@@ -28,14 +28,16 @@ def tensor(
     dtype: ir.DataType | None = None,
     name: str | None = None,
     doc_string: str | None = None,
-) -> _protocols.TensorProtocol:
+) -> _protocols.TensorProtocol | _protocols.SparseTensorProtocol:
     """Create a tensor value from an ArrayLike object or a TensorProto.
 
     The dtype must match the value. Reinterpretation of the value is
     not supported, unless if the value is a plain Python object, in which case
     it is converted to a numpy array with the given dtype.
 
-    ``value`` can be a numpy array, a plain Python object, or a TensorProto.
+    ``value`` can be a numpy array, a plain Python object, a TensorProto, or a
+    scipy sparse array. When ``value`` is a scipy sparse array, a
+    :class:`~onnx_ir.SparseTensor` is returned.
 
     .. warning::
         For 4bit dtypes, the value must be unpacked. Use :class:`~onnx_ir.PackedTensor`
@@ -59,18 +61,44 @@ def tensor(
         TorchTensor<FLOAT,[2]>(tensor([1., 2.]), name='torch_tensor')
 
     Args:
-        value: The numpy array to create the tensor from.
+        value: The value to create the tensor from. Can be a numpy array, a plain
+            Python object, a TensorProto, or a scipy sparse array (any format;
+            converted to COO internally).
         dtype: The data type of the tensor.
         name: The name of the tensor.
         doc_string: The documentation string of the tensor.
 
     Returns:
-        A tensor value.
+        A :class:`~onnx_ir.Tensor` for dense inputs, or a
+        :class:`~onnx_ir.SparseTensor` when ``value`` is a scipy sparse array.
 
     Raises:
         ValueError: If the dtype does not match the value when value is not a plain Python
             object like ``list[int]``.
     """
+    # Handle scipy sparse arrays before the TensorProtocol check so that scipy arrays
+    # are not accidentally handled by a different branch.
+    try:
+        import scipy.sparse as _scipy_sparse  # type: ignore[import-untyped]
+
+        if isinstance(value, (_scipy_sparse.sparray, _scipy_sparse.spmatrix)):
+            coo = value.tocoo()
+            data: np.ndarray = np.asarray(coo.data)
+            values_tensor = _core.Tensor(
+                data, _enums.DataType.from_numpy(data.dtype), name=name
+            )
+            coords = coo.coords  # tuple of per-dimension index arrays
+            indices_array = np.stack(coords, axis=0).astype(np.int64)
+            indices_tensor = _core.Tensor(indices_array, _enums.DataType.INT64)
+            return _core.SparseTensor(
+                values_tensor,
+                indices_tensor,
+                list(value.shape),
+                doc_string=doc_string,
+            )
+    except ImportError:
+        pass
+
     if isinstance(value, _protocols.TensorProtocol):
         if dtype is not None and dtype != value.dtype:
             raise ValueError(

--- a/src/onnx_ir/_convenience/_constructors.py
+++ b/src/onnx_ir/_convenience/_constructors.py
@@ -28,16 +28,14 @@ def tensor(
     dtype: ir.DataType | None = None,
     name: str | None = None,
     doc_string: str | None = None,
-) -> _protocols.TensorProtocol | _protocols.SparseTensorProtocol:
+) -> _protocols.TensorProtocol:
     """Create a tensor value from an ArrayLike object or a TensorProto.
 
     The dtype must match the value. Reinterpretation of the value is
     not supported, unless if the value is a plain Python object, in which case
     it is converted to a numpy array with the given dtype.
 
-    ``value`` can be a numpy array, a plain Python object, a TensorProto, or a
-    scipy sparse array. When ``value`` is a scipy sparse array, a
-    :class:`~onnx_ir.SparseTensor` is returned.
+    ``value`` can be a numpy array, a plain Python object, or a TensorProto.
 
     .. warning::
         For 4bit dtypes, the value must be unpacked. Use :class:`~onnx_ir.PackedTensor`
@@ -60,45 +58,23 @@ def tensor(
         >>> ir.tensor(torch.tensor([1.0, 2.0]), name="torch_tensor")
         TorchTensor<FLOAT,[2]>(tensor([1., 2.]), name='torch_tensor')
 
+    To create a sparse tensor from a scipy sparse array, use
+    :meth:`~onnx_ir.SparseTensor.from_scipy_sparse`.
+
     Args:
         value: The value to create the tensor from. Can be a numpy array, a plain
-            Python object, a TensorProto, or a scipy sparse array (any format;
-            converted to COO internally).
+            Python object, or a TensorProto.
         dtype: The data type of the tensor.
         name: The name of the tensor.
         doc_string: The documentation string of the tensor.
 
     Returns:
-        A :class:`~onnx_ir.Tensor` for dense inputs, or a
-        :class:`~onnx_ir.SparseTensor` when ``value`` is a scipy sparse array.
+        A :class:`~onnx_ir.Tensor` object.
 
     Raises:
         ValueError: If the dtype does not match the value when value is not a plain Python
             object like ``list[int]``.
     """
-    # Handle scipy sparse arrays before the TensorProtocol check so that scipy arrays
-    # are not accidentally handled by a different branch.
-    try:
-        import scipy.sparse as _scipy_sparse  # type: ignore[import-untyped]
-
-        if isinstance(value, (_scipy_sparse.sparray, _scipy_sparse.spmatrix)):
-            coo = value.tocoo()
-            data: np.ndarray = np.asarray(coo.data)
-            values_tensor = _core.Tensor(
-                data, _enums.DataType.from_numpy(data.dtype), name=name
-            )
-            coords = coo.coords  # tuple of per-dimension index arrays
-            indices_array = np.stack(coords, axis=0).astype(np.int64)
-            indices_tensor = _core.Tensor(indices_array, _enums.DataType.INT64)
-            return _core.SparseTensor(
-                values_tensor,
-                indices_tensor,
-                list(value.shape),
-                doc_string=doc_string,
-            )
-    except ImportError:
-        pass
-
     if isinstance(value, _protocols.TensorProtocol):
         if dtype is not None and dtype != value.dtype:
             raise ValueError(

--- a/src/onnx_ir/_convenience/_constructors_test.py
+++ b/src/onnx_ir/_convenience/_constructors_test.py
@@ -5,6 +5,7 @@
 import unittest
 
 import numpy as np
+import pytest
 
 import onnx_ir as ir
 from onnx_ir._convenience import _constructors
@@ -25,6 +26,50 @@ class ConstructorsTest(unittest.TestCase):
     def test_tensor_handles_empty_sequence_with_dtype(self):
         tensor = _constructors.tensor([], dtype=ir.DataType.FLOAT)
         np.testing.assert_array_equal(tensor.numpy(), np.array([], dtype=np.float32))
+
+    def test_tensor_returns_sparse_tensor_for_scipy_coo(self):
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        data = np.array([1.0, 2.0], dtype=np.float32)
+        coo = sp.coo_array((data, ([0, 1], [1, 0])), shape=(3, 3))
+        sparse = _constructors.tensor(coo, name="my_sparse")
+        self.assertIsInstance(sparse, ir.SparseTensor)
+        self.assertEqual(sparse.name, "my_sparse")
+        self.assertEqual(sparse.dims, [3, 3])
+        np.testing.assert_array_equal(sparse.values.numpy(), data)
+        np.testing.assert_array_equal(
+            sparse.indices.numpy(), np.array([[0, 1], [1, 0]], dtype=np.int64)
+        )
+
+    def test_tensor_returns_sparse_tensor_for_scipy_csr(self):
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        csr = sp.eye(4, format="csr", dtype=np.float64)
+        sparse = _constructors.tensor(csr)
+        self.assertIsInstance(sparse, ir.SparseTensor)
+        self.assertEqual(sparse.dims, [4, 4])
+        result = sparse.numpy()
+        np.testing.assert_array_equal(result.toarray(), np.eye(4, dtype=np.float64))
+
+    def test_tensor_scipy_roundtrip(self):
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        data = np.array([3.0, 7.0], dtype=np.float64)
+        original = sp.coo_array((data, ([0, 2], [1, 0])), shape=(4, 3))
+        sparse = _constructors.tensor(original)
+        roundtripped = sparse.numpy()
+        np.testing.assert_array_equal(roundtripped.toarray(), original.toarray())
+
+    def test_tensor_scipy_doc_string_is_set(self):
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        csr = sp.eye(2, format="csr", dtype=np.float32)
+        sparse = _constructors.tensor(csr, doc_string="my doc")
+        self.assertEqual(sparse.doc_string, "my doc")
 
 
 class ValueConstructorTest(unittest.TestCase):

--- a/src/onnx_ir/_convenience/_constructors_test.py
+++ b/src/onnx_ir/_convenience/_constructors_test.py
@@ -68,6 +68,18 @@ class ConstructorsTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             ir.SparseTensor.from_scipy_sparse(np.eye(2, dtype=np.float32))
 
+    def test_from_scipy_sparse_legacy_spmatrix(self):
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        # Legacy spmatrix.tocoo() returns a coo_matrix, which lacks ``coords``
+        # on scipy<1.13; from_scipy_sparse() must still handle it.
+        matrix = sp.csr_matrix(np.array([[1.0, 0.0, 2.0], [0.0, 3.0, 0.0]], dtype=np.float32))
+        sparse = ir.SparseTensor.from_scipy_sparse(matrix)
+        self.assertIsInstance(sparse, ir.SparseTensor)
+        self.assertEqual(sparse.dims, [2, 3])
+        np.testing.assert_array_equal(sparse.numpy().toarray(), matrix.toarray())
+
 
 class ValueConstructorTest(unittest.TestCase):
     def test_value_minimal_creation(self):

--- a/src/onnx_ir/_convenience/_constructors_test.py
+++ b/src/onnx_ir/_convenience/_constructors_test.py
@@ -27,13 +27,13 @@ class ConstructorsTest(unittest.TestCase):
         tensor = _constructors.tensor([], dtype=ir.DataType.FLOAT)
         np.testing.assert_array_equal(tensor.numpy(), np.array([], dtype=np.float32))
 
-    def test_tensor_returns_sparse_tensor_for_scipy_coo(self):
+    def test_from_scipy_sparse_coo(self):
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         data = np.array([1.0, 2.0], dtype=np.float32)
         coo = sp.coo_array((data, ([0, 1], [1, 0])), shape=(3, 3))
-        sparse = _constructors.tensor(coo, name="my_sparse")
+        sparse = ir.SparseTensor.from_scipy_sparse(coo, name="my_sparse")
         self.assertIsInstance(sparse, ir.SparseTensor)
         self.assertEqual(sparse.name, "my_sparse")
         self.assertEqual(sparse.dims, [3, 3])
@@ -42,34 +42,31 @@ class ConstructorsTest(unittest.TestCase):
             sparse.indices.numpy(), np.array([[0, 1], [1, 0]], dtype=np.int64)
         )
 
-    def test_tensor_returns_sparse_tensor_for_scipy_csr(self):
+    def test_from_scipy_sparse_csr(self):
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         csr = sp.eye(4, format="csr", dtype=np.float64)
-        sparse = _constructors.tensor(csr)
+        sparse = ir.SparseTensor.from_scipy_sparse(csr)
         self.assertIsInstance(sparse, ir.SparseTensor)
         self.assertEqual(sparse.dims, [4, 4])
         result = sparse.numpy()
         np.testing.assert_array_equal(result.toarray(), np.eye(4, dtype=np.float64))
 
-    def test_tensor_scipy_roundtrip(self):
+    def test_from_scipy_sparse_roundtrip(self):
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         data = np.array([3.0, 7.0], dtype=np.float64)
         original = sp.coo_array((data, ([0, 2], [1, 0])), shape=(4, 3))
-        sparse = _constructors.tensor(original)
+        sparse = ir.SparseTensor.from_scipy_sparse(original)
         roundtripped = sparse.numpy()
         np.testing.assert_array_equal(roundtripped.toarray(), original.toarray())
 
-    def test_tensor_scipy_doc_string_is_set(self):
+    def test_from_scipy_sparse_rejects_dense_array(self):
         pytest.importorskip("scipy")
-        import scipy.sparse as sp
-
-        csr = sp.eye(2, format="csr", dtype=np.float32)
-        sparse = _constructors.tensor(csr, doc_string="my doc")
-        self.assertEqual(sparse.doc_string, "my doc")
+        with self.assertRaises(TypeError):
+            ir.SparseTensor.from_scipy_sparse(np.eye(2, dtype=np.float32))
 
 
 class ValueConstructorTest(unittest.TestCase):

--- a/src/onnx_ir/_convenience/_constructors_test.py
+++ b/src/onnx_ir/_convenience/_constructors_test.py
@@ -38,9 +38,28 @@ class ConstructorsTest(unittest.TestCase):
         self.assertEqual(sparse.name, "my_sparse")
         self.assertEqual(sparse.dims, [3, 3])
         np.testing.assert_array_equal(sparse.values.numpy(), data)
+        # Indices shape is [NNZ, rank]: each row is one non-zero's coordinate
+        # NNZ 0 at (row=0, col=1), NNZ 1 at (row=1, col=0)
         np.testing.assert_array_equal(
             sparse.indices.numpy(), np.array([[0, 1], [1, 0]], dtype=np.int64)
         )
+
+    def test_from_scipy_sparse_coo_asymmetric_nnz_rank(self):
+        """from_scipy_sparse with NNZ != rank produces [NNZ, rank] indices (validates layout)."""
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        # NNZ=4, rank=2 — layout ambiguity only resolved when NNZ != rank
+        rows = [0, 1, 3, 4]
+        cols = [0, 3, 1, 2]
+        data = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        coo = sp.coo_array((data, (rows, cols)), shape=(5, 4))
+        sparse = ir.SparseTensor.from_scipy_sparse(coo)
+        self.assertEqual(sparse.dims, [5, 4])
+        # Indices must have shape [NNZ=4, rank=2]
+        self.assertEqual(sparse.indices.numpy().shape, (4, 2))
+        # Round-trip via numpy() must reproduce the original dense array
+        np.testing.assert_array_equal(sparse.numpy().toarray(), coo.toarray())
 
     def test_from_scipy_sparse_csr(self):
         pytest.importorskip("scipy")

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1438,6 +1438,68 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
             self._metadata = _metadata.MetadataStore()
         return self._metadata
 
+    def as_tensor(self, *, lazy: bool = False) -> "TensorBase":
+        """Convert this sparse tensor to a dense :class:`Tensor`.
+
+        The conversion uses NumPy to materialize the dense array by placing
+        each non-zero value at its corresponding index.
+
+        Two index layouts are supported (following the ONNX specification):
+
+        * **1-D indices** (shape ``[NNZ]``): flat linear indices in row-major
+          (C) order, as if the tensor were flattened to 1-D first.
+        * **2-D indices** (shape ``[rank, NNZ]``): per-dimension indices where
+          row *i* contains the index along dimension *i* for every non-zero.
+
+        Args:
+            lazy: When ``False`` (the default), the dense array is computed
+                immediately and a :class:`Tensor` is returned.  When ``True``,
+                a :class:`LazyTensor` is returned whose data is not computed
+                until it is first accessed.
+
+        Returns:
+            A :class:`Tensor` (or :class:`LazyTensor` when ``lazy=True``)
+            with shape equal to :attr:`dims` and dtype equal to the dtype of
+            the :attr:`values` tensor.
+
+        Example::
+
+            >>> import numpy as np
+            >>> import onnx_ir as ir
+            >>> values = ir.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+            >>> # 1-D linear indices: position 1 and position 3 in a 2x3 tensor
+            >>> indices = ir.Tensor(np.array([1, 3], dtype=np.int64))
+            >>> sparse = ir.SparseTensor(values=values, indices=indices, dims=[2, 3])
+            >>> dense = sparse.as_tensor()
+            >>> dense.numpy()
+            array([[0., 1., 0.],
+                   [2., 0., 0.]], dtype=float32)
+        """
+
+        def _compute() -> "Tensor":
+            values_array = self._values.numpy()
+            indices_array = self._indices.numpy()
+            dtype = self._values.dtype
+            np_dtype = dtype.numpy()
+            dense = np.zeros(self._dims, dtype=np_dtype)
+            if indices_array.ndim == 1:
+                # Linear (flat) indices in row-major order
+                multi_indices = np.unravel_index(indices_array, self._dims)
+            else:
+                # Shape [rank, NNZ] – each row is one dimension's indices
+                multi_indices = tuple(indices_array[i] for i in range(indices_array.shape[0]))
+            dense[multi_indices] = values_array
+            return Tensor(dense, dtype)
+
+        if lazy:
+            return LazyTensor(
+                _compute,
+                dtype=self._values.dtype,
+                shape=Shape(self._dims),
+                name=self.name,
+            )
+        return _compute()
+
     def __repr__(self) -> str:
         return (
             f"SparseTensor("

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1359,26 +1359,77 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
 
     def __init__(
         self,
-        values: _protocols.TensorProtocol,
-        indices: _protocols.TensorProtocol,
-        dims: Sequence[int],
+        values: _protocols.TensorProtocol | Any,
+        indices: _protocols.TensorProtocol | None = None,
+        dims: Sequence[int] | None = None,
         *,
+        name: str | None = None,
         doc_string: str | None = None,
         metadata_props: dict[str, str] | None = None,
     ) -> None:
         """Initialize a sparse tensor.
 
+        The sparse tensor can be created in two ways:
+
+        1. From explicit COO components (``values``, ``indices``, ``dims``).
+        2. From a **scipy sparse array** (``scipy.sparse.sparray`` or
+           ``scipy.sparse.spmatrix``), in which case ``indices`` and ``dims``
+           are derived from the sparse array automatically.
+
         Args:
-            values: A tensor containing the non-zero values. The name of this tensor
-                is used as the name of the sparse tensor (per the ONNX specification).
-            indices: A tensor of ``INT64`` containing the indices of the non-zero values.
-            dims: The dense shape of the sparse tensor.
+            values: Either a :class:`TensorProtocol` containing the non-zero values,
+                or a scipy sparse array (any format; it will be converted to COO
+                internally).  When a :class:`TensorProtocol` is provided, ``indices``
+                and ``dims`` must also be given.  The name of the ``values`` tensor
+                is used as the name of the sparse tensor (per the ONNX specification)
+                unless ``name`` is explicitly supplied.
+            indices: A tensor of ``INT64`` containing the indices of the non-zero
+                values.  Required when ``values`` is a :class:`TensorProtocol`;
+                ignored when ``values`` is a scipy sparse array.
+            dims: The dense shape of the sparse tensor.  Required when ``values``
+                is a :class:`TensorProtocol``; inferred from the scipy array shape
+                otherwise.
+            name: Optional name for the sparse tensor.  When ``values`` is a
+                :class:`TensorProtocol`, this overrides the name stored on that
+                tensor.  When constructing from a scipy sparse array, this sets
+                the name on the internally created ``values`` tensor.
             doc_string: Optional documentation string.
             metadata_props: Optional metadata properties.
         """
-        self._values = values
-        self._indices = indices
-        self._dims: list[int] = list(dims)
+        try:
+            import scipy.sparse as _scipy_sparse  # type: ignore[import-untyped]
+
+            _is_scipy = isinstance(values, (_scipy_sparse.sparray, _scipy_sparse.spmatrix))
+        except ImportError:
+            _is_scipy = False
+
+        if _is_scipy:
+            # Convert scipy sparse to COO and extract components
+            coo = values.tocoo()  # type: ignore[union-attr]
+            data: np.ndarray = np.asarray(coo.data)
+            dtype = _enums.DataType.from_numpy(data.dtype)
+            coords = coo.coords  # tuple of per-dimension index arrays
+            indices_array = np.stack(coords, axis=0).astype(np.int64)
+            self._values: _protocols.TensorProtocol = Tensor(data, dtype, name=name)
+            self._indices: _protocols.TensorProtocol = Tensor(
+                indices_array, _enums.DataType.INT64
+            )
+            self._dims: list[int] = list(values.shape)  # type: ignore[union-attr]
+        else:
+            if not isinstance(values, _protocols.TensorProtocol):
+                raise TypeError(
+                    f"'values' must be a TensorProtocol or a scipy sparse array, got {type(values)!r}"
+                )
+            if indices is None:
+                raise TypeError("'indices' must be provided when 'values' is a TensorProtocol")
+            if dims is None:
+                raise TypeError("'dims' must be provided when 'values' is a TensorProtocol")
+            self._values = values
+            self._indices = indices
+            self._dims = list(dims)
+            if name is not None:
+                self._values.name = name  # type: ignore[misc]
+
         self._doc_string = doc_string
         self._metadata: _metadata.MetadataStore | None = None
         self._metadata_props: dict[str, str] | None = metadata_props
@@ -1437,6 +1488,60 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         if self._metadata is None:
             self._metadata = _metadata.MetadataStore()
         return self._metadata
+
+    def numpy(self) -> Any:
+        """Return the sparse tensor as a :class:`scipy.sparse.coo_array`.
+
+        The returned array has the same shape as :attr:`dims` and the same
+        element type as :attr:`values`.
+
+        Two index layouts are supported (following the ONNX specification):
+
+        * **1-D indices** (shape ``[NNZ]``): flat linear indices in row-major
+          (C) order; these are converted to per-dimension coordinates via
+          :func:`numpy.unravel_index`.
+        * **2-D indices** (shape ``[rank, NNZ]``): per-dimension indices where
+          row *i* contains the index along dimension *i* for every non-zero.
+
+        Returns:
+            A ``scipy.sparse.coo_array`` with the non-zero data placed at the
+            corresponding coordinates.
+
+        Raises:
+            ImportError: If ``scipy`` is not installed.
+
+        Example::
+
+            >>> import numpy as np
+            >>> import onnx_ir as ir
+            >>> values = ir.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+            >>> indices = ir.Tensor(np.array([[0, 1], [1, 0]], dtype=np.int64))
+            >>> sparse = ir.SparseTensor(values=values, indices=indices, dims=[3, 3])
+            >>> sp = sparse.numpy()
+            >>> sp.toarray()
+            array([[0., 1., 0.],
+                   [2., 0., 0.],
+                   [0., 0., 0.]], dtype=float32)
+        """
+        try:
+            import scipy.sparse as _scipy_sparse  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise ImportError(
+                "scipy is required for SparseTensor.numpy(). "
+                "Install it with 'pip install scipy'."
+            ) from e
+
+        values_array = self._values.numpy()
+        indices_array = self._indices.numpy()
+        if indices_array.ndim == 1:
+            # Linear (flat) indices → per-dimension coordinates
+            coords = np.unravel_index(indices_array, self._dims)
+        else:
+            # Shape [rank, NNZ] – each row is one dimension's indices
+            coords = tuple(indices_array[i] for i in range(indices_array.shape[0]))
+        return _scipy_sparse.coo_array(
+            (values_array, coords), shape=tuple(self._dims)
+        )
 
     def as_tensor(self, *, lazy: bool = False) -> "TensorBase":
         """Convert this sparse tensor to a dense :class:`Tensor`.

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1506,13 +1506,13 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
             # Linear (flat) indices → per-dimension coordinates
             coords = np.unravel_index(indices_array, self._dims)
         else:
-            # Shape [rank, NNZ] – each row is one dimension's indices
+            # Shape [rank, NNZ] - each row is one dimension's indices
             coords = tuple(indices_array[i] for i in range(indices_array.shape[0]))
         return _scipy_sparse.coo_array(
             (values_array, coords), shape=tuple(self._dims)
         )
 
-    def as_tensor(self, *, lazy: bool = False) -> "TensorBase":
+    def as_tensor(self, *, lazy: bool = False) -> TensorBase:
         """Convert this sparse tensor to a dense :class:`Tensor`.
 
         The conversion uses NumPy to materialize the dense array by placing
@@ -1550,7 +1550,7 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
                    [2., 0., 0.]], dtype=float32)
         """
 
-        def _compute() -> "Tensor":
+        def _compute() -> Tensor:
             values_array = self._values.numpy()
             indices_array = self._indices.numpy()
             dtype = self._values.dtype
@@ -1560,7 +1560,7 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
                 # Linear (flat) indices in row-major order
                 multi_indices = np.unravel_index(indices_array, self._dims)
             else:
-                # Shape [rank, NNZ] – each row is one dimension's indices
+                # Shape [rank, NNZ] - each row is one dimension's indices
                 multi_indices = tuple(indices_array[i] for i in range(indices_array.shape[0]))
             dense[multi_indices] = values_array
             return Tensor(dense, dtype)

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1359,76 +1359,45 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
 
     def __init__(
         self,
-        values: _protocols.TensorProtocol | Any,
-        indices: _protocols.TensorProtocol | None = None,
-        dims: Sequence[int] | None = None,
+        values: _protocols.TensorProtocol,
+        indices: _protocols.TensorProtocol,
+        dims: Sequence[int],
         *,
         name: str | None = None,
         doc_string: str | None = None,
         metadata_props: dict[str, str] | None = None,
     ) -> None:
-        """Initialize a sparse tensor.
-
-        The sparse tensor can be created in two ways:
-
-        1. From explicit COO components (``values``, ``indices``, ``dims``).
-        2. From a **scipy sparse array** (``scipy.sparse.sparray`` or
-           ``scipy.sparse.spmatrix``), in which case ``indices`` and ``dims``
-           are derived from the sparse array automatically.
+        """Initialize a sparse tensor from explicit COO components.
 
         Args:
-            values: Either a :class:`TensorProtocol` containing the non-zero values,
-                or a scipy sparse array (any format; it will be converted to COO
-                internally).  When a :class:`TensorProtocol` is provided, ``indices``
-                and ``dims`` must also be given.  The name of the ``values`` tensor
-                is used as the name of the sparse tensor (per the ONNX specification)
-                unless ``name`` is explicitly supplied.
+            values: A :class:`TensorProtocol` containing the non-zero values.
+                The name of the ``values`` tensor is used as the name of the sparse
+                tensor (per the ONNX specification) unless ``name`` is explicitly
+                supplied.
             indices: A tensor of ``INT64`` containing the indices of the non-zero
-                values.  Required when ``values`` is a :class:`TensorProtocol`;
-                ignored when ``values`` is a scipy sparse array.
-            dims: The dense shape of the sparse tensor.  Required when ``values``
-                is a :class:`TensorProtocol``; inferred from the scipy array shape
-                otherwise.
-            name: Optional name for the sparse tensor.  When ``values`` is a
-                :class:`TensorProtocol`, this overrides the name stored on that
-                tensor.  When constructing from a scipy sparse array, this sets
-                the name on the internally created ``values`` tensor.
+                values.
+            dims: The dense shape of the sparse tensor.
+            name: Optional name for the sparse tensor.  When provided, this overrides
+                the name stored on the ``values`` tensor.
             doc_string: Optional documentation string.
             metadata_props: Optional metadata properties.
+
+        Note:
+            To construct a :class:`SparseTensor` from a scipy sparse array, use the
+            :func:`~onnx_ir.tensor` convenience function::
+
+                sparse = ir.tensor(scipy_array, name="my_sparse")
         """
-        try:
-            import scipy.sparse as _scipy_sparse  # type: ignore[import-untyped]
-
-            _is_scipy = isinstance(values, (_scipy_sparse.sparray, _scipy_sparse.spmatrix))
-        except ImportError:
-            _is_scipy = False
-
-        if _is_scipy:
-            # Convert scipy sparse to COO and extract components
-            coo = values.tocoo()  # type: ignore[union-attr]
-            data: np.ndarray = np.asarray(coo.data)
-            dtype = _enums.DataType.from_numpy(data.dtype)
-            coords = coo.coords  # tuple of per-dimension index arrays
-            indices_array = np.stack(coords, axis=0).astype(np.int64)
-            self._values: _protocols.TensorProtocol = Tensor(data, dtype, name=name)
-            self._indices: _protocols.TensorProtocol = Tensor(
-                indices_array, _enums.DataType.INT64
+        if not isinstance(values, _protocols.TensorProtocol):
+            raise TypeError(
+                f"'values' must be a TensorProtocol, got {type(values)!r}. "
+                "To construct from a scipy sparse array, use ir.tensor()."
             )
-            self._dims: list[int] = list(values.shape)  # type: ignore[union-attr]
-        else:
-            if not isinstance(values, _protocols.TensorProtocol):
-                raise TypeError(
-                    f"'values' must be a TensorProtocol or a scipy sparse array, got {type(values)!r}"
-                )
-            if indices is None:
-                raise TypeError("'indices' must be provided when 'values' is a TensorProtocol")
-            if dims is None:
-                raise TypeError("'dims' must be provided when 'values' is a TensorProtocol")
-            self._values = values
-            self._indices = indices
-            self._dims = list(dims)
-            if name is not None:
-                self._values.name = name  # type: ignore[misc]
+        self._values: _protocols.TensorProtocol = values
+        self._indices: _protocols.TensorProtocol = indices
+        self._dims: list[int] = list(dims)
+        if name is not None:
+            self._values.name = name  # type: ignore[misc]
 
         self._doc_string = doc_string
         self._metadata: _metadata.MetadataStore | None = None

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1342,18 +1342,18 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         name: Optional name for the sparse tensor. When used as an initializer, this
             name must match the corresponding graph value name. It is stored as the
             name of the ``values`` tensor to match the ONNX specification.
-        doc_string: Optional documentation string.
-        metadata_props: Optional metadata properties that will be serialized to the
-            ONNX proto.
         meta: Metadata store for graph transform passes (not serialized).
+
+    Note:
+        The ONNX ``SparseTensorProto`` only stores ``values``, ``indices`` and
+        ``dims``, so a sparse tensor has no serializable ``doc_string`` or
+        ``metadata_props``. Use :attr:`meta` for in-memory annotations.
     """
 
     __slots__ = (
         "_dims",
-        "_doc_string",
         "_indices",
         "_metadata",
-        "_metadata_props",
         "_values",
     )
 
@@ -1364,8 +1364,6 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         dims: Sequence[int],
         *,
         name: str | None = None,
-        doc_string: str | None = None,
-        metadata_props: dict[str, str] | None = None,
     ) -> None:
         """Initialize a sparse tensor from explicit COO components.
 
@@ -1379,19 +1377,17 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
             dims: The dense shape of the sparse tensor.
             name: Optional name for the sparse tensor.  When provided, this overrides
                 the name stored on the ``values`` tensor.
-            doc_string: Optional documentation string.
-            metadata_props: Optional metadata properties.
 
         Note:
             To construct a :class:`SparseTensor` from a scipy sparse array, use the
-            :func:`~onnx_ir.tensor` convenience function::
+            :meth:`from_scipy_sparse` classmethod::
 
-                sparse = ir.tensor(scipy_array, name="my_sparse")
+                sparse = ir.SparseTensor.from_scipy_sparse(scipy_array, name="my_sparse")
         """
         if not isinstance(values, _protocols.TensorProtocol):
             raise TypeError(
                 f"'values' must be a TensorProtocol, got {type(values)!r}. "
-                "To construct from a scipy sparse array, use ir.tensor()."
+                "To construct from a scipy sparse array, use SparseTensor.from_scipy_sparse()."
             )
         self._values: _protocols.TensorProtocol = values
         self._indices: _protocols.TensorProtocol = indices
@@ -1399,9 +1395,60 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         if name is not None:
             self._values.name = name  # type: ignore[misc]
 
-        self._doc_string = doc_string
         self._metadata: _metadata.MetadataStore | None = None
-        self._metadata_props: dict[str, str] | None = metadata_props
+
+    @classmethod
+    def from_scipy_sparse(
+        cls,
+        array: Any,
+        *,
+        name: str | None = None,
+    ) -> SparseTensor:
+        """Create a :class:`SparseTensor` from a ``scipy.sparse`` array.
+
+        The array can be in any scipy sparse format; it is converted to COO
+        internally. The dense shape is taken from the array's ``shape``.
+
+        Args:
+            array: A ``scipy.sparse`` array or matrix.
+            name: Optional name for the resulting sparse tensor.
+
+        Returns:
+            A :class:`SparseTensor` in COO format with 2-D ``[rank, NNZ]`` indices.
+
+        Raises:
+            ImportError: If ``scipy`` is not installed.
+            TypeError: If ``array`` is not a ``scipy.sparse`` array.
+
+        Example::
+
+            >>> import numpy as np
+            >>> import scipy.sparse as sp
+            >>> import onnx_ir as ir
+            >>> coo = sp.coo_array((np.array([1.0, 2.0], dtype=np.float32), ([0, 1], [1, 0])), shape=(3, 3))
+            >>> sparse = ir.SparseTensor.from_scipy_sparse(coo, name="my_sparse")
+            >>> sparse.dims
+            [3, 3]
+        """
+        try:
+            import scipy.sparse as _scipy_sparse  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise ImportError(
+                "scipy is required for SparseTensor.from_scipy_sparse(). "
+                "Install it with 'pip install scipy'."
+            ) from e
+
+        if not isinstance(array, (_scipy_sparse.sparray, _scipy_sparse.spmatrix)):
+            raise TypeError(
+                f"'array' must be a scipy.sparse array or matrix, got {type(array)!r}."
+            )
+
+        coo = array.tocoo()
+        data: np.ndarray = np.asarray(coo.data)
+        values_tensor = Tensor(data, _enums.DataType.from_numpy(data.dtype), name=name)
+        indices_array = np.stack(coo.coords, axis=0).astype(np.int64)
+        indices_tensor = Tensor(indices_array, _enums.DataType.INT64)
+        return cls(values_tensor, indices_tensor, list(array.shape))
 
     @property
     def name(self) -> str | None:
@@ -1432,27 +1479,11 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         return self._dims
 
     @property
-    def doc_string(self) -> str | None:
-        """The documentation string."""
-        return self._doc_string
-
-    @doc_string.setter
-    def doc_string(self, value: str | None) -> None:
-        self._doc_string = value
-
-    @property
-    def metadata_props(self) -> dict[str, str]:
-        """The metadata properties of the sparse tensor."""
-        if self._metadata_props is None:
-            self._metadata_props = {}
-        return self._metadata_props
-
-    @property
     def meta(self) -> _metadata.MetadataStore:
         """The metadata store for intermediate analysis.
 
-        Write to the :attr:`metadata_props` if you would like the metadata to be serialized
-        to the ONNX proto.
+        This is never serialized to the ONNX proto because the
+        ``SparseTensorProto`` has no field to hold it.
         """
         if self._metadata is None:
             self._metadata = _metadata.MetadataStore()
@@ -1508,9 +1539,7 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         else:
             # Shape [rank, NNZ] - each row is one dimension's indices
             coords = tuple(indices_array[i] for i in range(indices_array.shape[0]))
-        return _scipy_sparse.coo_array(
-            (values_array, coords), shape=tuple(self._dims)
-        )
+        return _scipy_sparse.coo_array((values_array, coords), shape=tuple(self._dims))
 
     def as_tensor(self, *, lazy: bool = False) -> TensorBase:
         """Convert this sparse tensor to a dense :class:`Tensor`.
@@ -1576,11 +1605,7 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
 
     def __repr__(self) -> str:
         return (
-            f"SparseTensor("
-            f"name={self.name!r}, "
-            f"dims={self._dims!r}, "
-            f"nnz={self._values.size!r}"
-            f")"
+            f"SparseTensor(name={self.name!r}, dims={self._dims!r}, nnz={self._values.size!r})"
         )
 
 

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -3261,7 +3261,7 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
                 )
 
         # Rename the backing constant tensor
-        if self._const_value is not None and hasattr(self._const_value, "name"):
+        if isinstance(self._const_value, (_protocols.TensorProtocol, _protocols.SparseTensorProtocol)):
             self._const_value.name = value
 
         # Rename self

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -3056,6 +3056,7 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
     """
 
     __slots__ = (
+        "_const_sparse_value",
         "_const_value",
         "_graph",
         "_index",
@@ -3081,7 +3082,8 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
         shape: Shape | None = None,
         type: _protocols.TypeProtocol | None = None,
         doc_string: str | None = None,
-        const_value: _protocols.TensorProtocol | _protocols.SparseTensorProtocol | None = None,
+        const_value: _protocols.TensorProtocol | None = None,
+        const_sparse_value: _protocols.SparseTensorProtocol | None = None,
         metadata_props: dict[str, str] | None = None,
     ) -> None:
         """Initialize a value.
@@ -3102,7 +3104,8 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
             shape: The shape of the value.
             type: The type of the value.
             doc_string: The documentation string.
-            const_value: The constant tensor if the value is constant.
+            const_value: The constant dense tensor if the value is constant.
+            const_sparse_value: The constant sparse tensor if the value is a sparse constant.
             metadata_props: Metadata that will be serialized to the ONNX file.
         """
         self._producer: Node | None = producer
@@ -3116,6 +3119,7 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
         # TODO(justinchuby): Handle initialization when a const value is provided
         # We can get shape and type information from the const value
         self._const_value = const_value
+        self._const_sparse_value = const_sparse_value
         # Use a collection of (Node, int) to store uses. This is needed
         # because a single use can use the same value multiple times.
         # Use a dictionary to preserve insertion order so that the visiting order is deterministic
@@ -3160,10 +3164,10 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
 
     def _constant_tensor_part(self) -> str:
         """Display string for the constant tensor attached to str of Value."""
+        if self._const_sparse_value is not None:
+            return f"{{{self._const_sparse_value.__class__.__name__}(...)}}"
         if self.const_value is not None:
             # Only display when the const value is small
-            if isinstance(self.const_value, _protocols.SparseTensorProtocol):
-                return f"{{{self.const_value.__class__.__name__}(...)}}"
             if self.const_value.size <= 10:
                 return f"{{{self.const_value}}}"
             else:
@@ -3261,8 +3265,10 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
                 )
 
         # Rename the backing constant tensor
-        if isinstance(self._const_value, (_protocols.TensorProtocol, _protocols.SparseTensorProtocol)):
+        if isinstance(self._const_value, _protocols.TensorProtocol):
             self._const_value.name = value
+        if isinstance(self._const_sparse_value, _protocols.SparseTensorProtocol):
+            self._const_sparse_value.name = value
 
         # Rename self
         old_name = self._name
@@ -3328,37 +3334,61 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
     @property
     def const_value(
         self,
-    ) -> _protocols.TensorProtocol | _protocols.SparseTensorProtocol | None:
-        """The backing constant tensor for the value.
+    ) -> _protocols.TensorProtocol | None:
+        """The backing constant dense tensor for the value.
 
         If the ``Value`` has a ``const_value`` and is part of a graph initializers
         dictionary, the value is an initialized value. Its ``const_value``
-        will appear as an ``initializer`` (for dense tensors) or ``sparse_initializer``
-        (for sparse tensors) in the GraphProto when serialized.
+        will appear as an ``initializer`` in the GraphProto when serialized.
 
         If the ``Value`` is not part of a graph initializers dictionary, the ``const_value``
         field will be ignored during serialization.
 
-        ``const_value`` can be backed by different raw data types, such as numpy arrays,
-        or a :class:`SparseTensor` for sparse initializers.
-        The only guarantee is that it conforms to :class:`TensorProtocol` or
-        :class:`SparseTensorProtocol`.
+        ``const_value`` can be backed by different raw data types, such as numpy arrays.
+        The only guarantee is that it conforms to :class:`TensorProtocol`.
+
+        For sparse tensors, use :attr:`const_sparse_value` instead.
         """
         return self._const_value
 
     @const_value.setter
     def const_value(
         self,
-        value: _protocols.TensorProtocol | _protocols.SparseTensorProtocol | None,
+        value: _protocols.TensorProtocol | None,
     ) -> None:
         if onnx_ir.DEBUG:
-            if value is not None and not isinstance(
-                value, (_protocols.TensorProtocol, _protocols.SparseTensorProtocol)
-            ):
+            if value is not None and not isinstance(value, _protocols.TensorProtocol):
                 raise TypeError(
-                    f"Expected value to be a TensorProtocol, SparseTensorProtocol, or None, got '{type(value)}'"
+                    f"Expected value to be a TensorProtocol or None, got '{type(value)}'"
                 )
         self._const_value = value
+
+    @property
+    def const_sparse_value(
+        self,
+    ) -> _protocols.SparseTensorProtocol | None:
+        """The backing constant sparse tensor for the value.
+
+        If the ``Value`` has a ``const_sparse_value`` and is part of a graph initializers
+        dictionary, the value is an initialized sparse value. Its ``const_sparse_value``
+        will appear as a ``sparse_initializer`` in the GraphProto when serialized.
+
+        If the ``Value`` is not part of a graph initializers dictionary, the
+        ``const_sparse_value`` field will be ignored during serialization.
+        """
+        return self._const_sparse_value
+
+    @const_sparse_value.setter
+    def const_sparse_value(
+        self,
+        value: _protocols.SparseTensorProtocol | None,
+    ) -> None:
+        if onnx_ir.DEBUG:
+            if value is not None and not isinstance(value, _protocols.SparseTensorProtocol):
+                raise TypeError(
+                    f"Expected value to be a SparseTensorProtocol or None, got '{type(value)}'"
+                )
+        self._const_sparse_value = value
 
     @property
     def meta(self) -> _metadata.MetadataStore:

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1327,6 +1327,127 @@ class PackedTensor(TensorBase, _protocols.TensorProtocol, Generic[TArrayCompatib
             file.write(self.tobytes())
 
 
+class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
+    """A sparse tensor in COO (Coordinate) format.
+
+    A sparse tensor stores only the non-zero values and their indices, along with
+    the dense shape (``dims``). This follows the ONNX ``SparseTensorProto`` format.
+
+    Attributes:
+        values: A :class:`TensorProtocol` containing the non-zero values. The shape
+            is ``[nnz]`` or ``[nnz, ...]`` depending on the storage format.
+        indices: A :class:`TensorProtocol` of ``INT64`` containing the linear or
+            multi-dimensional indices of the non-zero values.
+        dims: The dense shape of the sparse tensor as a list of integers.
+        name: Optional name for the sparse tensor. When used as an initializer, this
+            name must match the corresponding graph value name. It is stored as the
+            name of the ``values`` tensor to match the ONNX specification.
+        doc_string: Optional documentation string.
+        metadata_props: Optional metadata properties that will be serialized to the
+            ONNX proto.
+        meta: Metadata store for graph transform passes (not serialized).
+    """
+
+    __slots__ = (
+        "_dims",
+        "_doc_string",
+        "_indices",
+        "_metadata",
+        "_metadata_props",
+        "_values",
+    )
+
+    def __init__(
+        self,
+        values: _protocols.TensorProtocol,
+        indices: _protocols.TensorProtocol,
+        dims: Sequence[int],
+        *,
+        doc_string: str | None = None,
+        metadata_props: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize a sparse tensor.
+
+        Args:
+            values: A tensor containing the non-zero values. The name of this tensor
+                is used as the name of the sparse tensor (per the ONNX specification).
+            indices: A tensor of ``INT64`` containing the indices of the non-zero values.
+            dims: The dense shape of the sparse tensor.
+            doc_string: Optional documentation string.
+            metadata_props: Optional metadata properties.
+        """
+        self._values = values
+        self._indices = indices
+        self._dims: list[int] = list(dims)
+        self._doc_string = doc_string
+        self._metadata: _metadata.MetadataStore | None = None
+        self._metadata_props: dict[str, str] | None = metadata_props
+
+    @property
+    def name(self) -> str | None:
+        """The name of the sparse tensor.
+
+        Per the ONNX specification, the name of a sparse tensor is the name of its
+        ``values`` tensor.
+        """
+        return self._values.name
+
+    @name.setter
+    def name(self, value: str | None) -> None:
+        self._values.name = value
+
+    @property
+    def values(self) -> _protocols.TensorProtocol:
+        """The non-zero values of the sparse tensor."""
+        return self._values
+
+    @property
+    def indices(self) -> _protocols.TensorProtocol:
+        """The indices of the non-zero values."""
+        return self._indices
+
+    @property
+    def dims(self) -> list[int]:
+        """The dense shape of the sparse tensor."""
+        return self._dims
+
+    @property
+    def doc_string(self) -> str | None:
+        """The documentation string."""
+        return self._doc_string
+
+    @doc_string.setter
+    def doc_string(self, value: str | None) -> None:
+        self._doc_string = value
+
+    @property
+    def metadata_props(self) -> dict[str, str]:
+        """The metadata properties of the sparse tensor."""
+        if self._metadata_props is None:
+            self._metadata_props = {}
+        return self._metadata_props
+
+    @property
+    def meta(self) -> _metadata.MetadataStore:
+        """The metadata store for intermediate analysis.
+
+        Write to the :attr:`metadata_props` if you would like the metadata to be serialized
+        to the ONNX proto.
+        """
+        if self._metadata is None:
+            self._metadata = _metadata.MetadataStore()
+        return self._metadata
+
+    def __repr__(self) -> str:
+        return (
+            f"SparseTensor("
+            f"name={self.name!r}, "
+            f"dims={self._dims!r}, "
+            f"nnz={self._values.size!r}"
+            f")"
+        )
+
+
 class SymbolicDim(_protocols.SymbolicDimProtocol, _display.PrettyPrintable):
     """Immutable symbolic dimension that can be shared across multiple shapes.
 
@@ -2960,7 +3081,7 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
         shape: Shape | None = None,
         type: _protocols.TypeProtocol | None = None,
         doc_string: str | None = None,
-        const_value: _protocols.TensorProtocol | None = None,
+        const_value: _protocols.TensorProtocol | _protocols.SparseTensorProtocol | None = None,
         metadata_props: dict[str, str] | None = None,
     ) -> None:
         """Initialize a value.
@@ -3041,6 +3162,8 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
         """Display string for the constant tensor attached to str of Value."""
         if self.const_value is not None:
             # Only display when the const value is small
+            if isinstance(self.const_value, _protocols.SparseTensorProtocol):
+                return f"{{{self.const_value.__class__.__name__}(...)}}"
             if self.const_value.size <= 10:
                 return f"{{{self.const_value}}}"
             else:
@@ -3138,7 +3261,7 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
                 )
 
         # Rename the backing constant tensor
-        if self._const_value is not None:
+        if self._const_value is not None and hasattr(self._const_value, "name"):
             self._const_value.name = value
 
         # Rename self
@@ -3205,30 +3328,35 @@ class Value(WithArithmeticMethods, _protocols.ValueProtocol, _display.PrettyPrin
     @property
     def const_value(
         self,
-    ) -> _protocols.TensorProtocol | None:
+    ) -> _protocols.TensorProtocol | _protocols.SparseTensorProtocol | None:
         """The backing constant tensor for the value.
 
         If the ``Value`` has a ``const_value`` and is part of a graph initializers
         dictionary, the value is an initialized value. Its ``const_value``
-        will appear as an ``initializer`` in the GraphProto when serialized.
+        will appear as an ``initializer`` (for dense tensors) or ``sparse_initializer``
+        (for sparse tensors) in the GraphProto when serialized.
 
         If the ``Value`` is not part of a graph initializers dictionary, the ``const_value``
         field will be ignored during serialization.
 
-        ``const_value`` can be backed by different raw data types, such as numpy arrays.
-        The only guarantee is that it conforms TensorProtocol.
+        ``const_value`` can be backed by different raw data types, such as numpy arrays,
+        or a :class:`SparseTensor` for sparse initializers.
+        The only guarantee is that it conforms to :class:`TensorProtocol` or
+        :class:`SparseTensorProtocol`.
         """
         return self._const_value
 
     @const_value.setter
     def const_value(
         self,
-        value: _protocols.TensorProtocol | None,
+        value: _protocols.TensorProtocol | _protocols.SparseTensorProtocol | None,
     ) -> None:
         if onnx_ir.DEBUG:
-            if value is not None and not isinstance(value, _protocols.TensorProtocol):
+            if value is not None and not isinstance(
+                value, (_protocols.TensorProtocol, _protocols.SparseTensorProtocol)
+            ):
                 raise TypeError(
-                    f"Expected value to be a TensorProtocol or None, got '{type(value)}'"
+                    f"Expected value to be a TensorProtocol, SparseTensorProtocol, or None, got '{type(value)}'"
                 )
         self._const_value = value
 

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1446,7 +1446,12 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         coo = array.tocoo()
         data: np.ndarray = np.asarray(coo.data)
         values_tensor = Tensor(data, _enums.DataType.from_numpy(data.dtype), name=name)
-        indices_array = np.stack(coo.coords, axis=0).astype(np.int64)
+        # ``coords`` is only available on COO objects in scipy>=1.13. Fall back to
+        # ``(row, col)`` for legacy ``coo_matrix`` instances that lack it.
+        coords = getattr(coo, "coords", None)
+        if coords is None:
+            coords = (coo.row, coo.col)
+        indices_array = np.stack(coords, axis=0).astype(np.int64)
         indices_tensor = Tensor(indices_array, _enums.DataType.INT64)
         return cls(values_tensor, indices_tensor, list(array.shape))
 

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -1414,7 +1414,7 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
             name: Optional name for the resulting sparse tensor.
 
         Returns:
-            A :class:`SparseTensor` in COO format with 2-D ``[rank, NNZ]`` indices.
+            A :class:`SparseTensor` in COO format with 2-D ``[NNZ, rank]`` indices.
 
         Raises:
             ImportError: If ``scipy`` is not installed.
@@ -1451,7 +1451,7 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         coords = getattr(coo, "coords", None)
         if coords is None:
             coords = (coo.row, coo.col)
-        indices_array = np.stack(coords, axis=0).astype(np.int64)
+        indices_array = np.stack(coords, axis=1).astype(np.int64)
         indices_tensor = Tensor(indices_array, _enums.DataType.INT64)
         return cls(values_tensor, indices_tensor, list(array.shape))
 
@@ -1505,8 +1505,9 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
         * **1-D indices** (shape ``[NNZ]``): flat linear indices in row-major
           (C) order; these are converted to per-dimension coordinates via
           :func:`numpy.unravel_index`.
-        * **2-D indices** (shape ``[rank, NNZ]``): per-dimension indices where
-          row *i* contains the index along dimension *i* for every non-zero.
+        * **2-D indices** (shape ``[NNZ, rank]``): per-non-zero indices where
+          row *i* contains the full coordinate tuple of the *i*-th non-zero
+          element (one entry per dimension).
 
         Returns:
             A ``scipy.sparse.coo_array`` with the non-zero data placed at the
@@ -1520,6 +1521,7 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
             >>> import numpy as np
             >>> import onnx_ir as ir
             >>> values = ir.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+            >>> # 2-D indices shape [NNZ=2, rank=2]: row i is the coordinate of NNZ i
             >>> indices = ir.Tensor(np.array([[0, 1], [1, 0]], dtype=np.int64))
             >>> sparse = ir.SparseTensor(values=values, indices=indices, dims=[3, 3])
             >>> sp = sparse.numpy()
@@ -1542,8 +1544,8 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
             # Linear (flat) indices → per-dimension coordinates
             coords = np.unravel_index(indices_array, self._dims)
         else:
-            # Shape [rank, NNZ] - each row is one dimension's indices
-            coords = tuple(indices_array[i] for i in range(indices_array.shape[0]))
+            # Shape [NNZ, rank] - each row is one non-zero's coordinate tuple
+            coords = tuple(indices_array[:, j] for j in range(indices_array.shape[1]))
         return _scipy_sparse.coo_array((values_array, coords), shape=tuple(self._dims))
 
     def as_tensor(self, *, lazy: bool = False) -> TensorBase:
@@ -1556,8 +1558,9 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
 
         * **1-D indices** (shape ``[NNZ]``): flat linear indices in row-major
           (C) order, as if the tensor were flattened to 1-D first.
-        * **2-D indices** (shape ``[rank, NNZ]``): per-dimension indices where
-          row *i* contains the index along dimension *i* for every non-zero.
+        * **2-D indices** (shape ``[NNZ, rank]``): per-non-zero indices where
+          row *i* contains the full coordinate tuple of the *i*-th non-zero
+          element (one entry per dimension).
 
         Args:
             lazy: When ``False`` (the default), the dense array is computed
@@ -1594,8 +1597,10 @@ class SparseTensor(_protocols.SparseTensorProtocol, _display.PrettyPrintable):
                 # Linear (flat) indices in row-major order
                 multi_indices = np.unravel_index(indices_array, self._dims)
             else:
-                # Shape [rank, NNZ] - each row is one dimension's indices
-                multi_indices = tuple(indices_array[i] for i in range(indices_array.shape[0]))
+                # Shape [NNZ, rank] - each row is one non-zero's coordinate tuple
+                multi_indices = tuple(
+                    indices_array[:, j] for j in range(indices_array.shape[1])
+                )
             dense[multi_indices] = values_array
             return Tensor(dense, dtype)
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -3710,13 +3710,13 @@ class SparseTensorTest(unittest.TestCase):
         np.testing.assert_array_equal(result.toarray(), expected)
 
     def test_init_from_scipy_sparse(self):
-        """SparseTensor can be constructed via ir.tensor() from a scipy sparse array."""
+        """SparseTensor can be constructed via from_scipy_sparse() from a scipy sparse array."""
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         data = np.array([1.0, 2.0], dtype=np.float32)
         coo = sp.coo_array((data, ([0, 1], [1, 0])), shape=(3, 3))
-        sparse = ir.tensor(coo, name="test_sparse")
+        sparse = ir.SparseTensor.from_scipy_sparse(coo, name="test_sparse")
         self.assertEqual(sparse.name, "test_sparse")
         self.assertEqual(sparse.dims, [3, 3])
         np.testing.assert_array_equal(sparse.values.numpy(), data)
@@ -3725,25 +3725,25 @@ class SparseTensorTest(unittest.TestCase):
         )
 
     def test_init_from_scipy_non_coo_format(self):
-        """ir.tensor() from CSR and other scipy formats is supported."""
+        """from_scipy_sparse() from CSR and other scipy formats is supported."""
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         csr = sp.eye(3, format="csr", dtype=np.float32)
-        sparse = ir.tensor(csr)
+        sparse = ir.SparseTensor.from_scipy_sparse(csr)
         self.assertEqual(sparse.dims, [3, 3])
         # Round-trip through numpy()
         result = sparse.numpy()
         np.testing.assert_array_equal(result.toarray(), np.eye(3, dtype=np.float32))
 
     def test_scipy_roundtrip(self):
-        """A scipy sparse array survives a SparseTensor round-trip via ir.tensor()."""
+        """A scipy sparse array survives a SparseTensor round-trip via from_scipy_sparse()."""
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         data = np.array([3.0, 7.0], dtype=np.float64)
         original = sp.coo_array((data, ([0, 2], [1, 0])), shape=(4, 3))
-        sparse = ir.tensor(original)
+        sparse = ir.SparseTensor.from_scipy_sparse(original)
         roundtripped = sparse.numpy()
         np.testing.assert_array_equal(roundtripped.toarray(), original.toarray())
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -3644,15 +3644,17 @@ class SparseTensorTest(unittest.TestCase):
         np.testing.assert_array_equal(dense.numpy(), expected)
 
     def test_as_tensor_2d_per_dimension_indices(self):
-        """as_tensor converts 2-D per-dimension indices to a dense array."""
-        values = _core.Tensor(np.array([1.0, 2.0], dtype=np.float32))
-        # Shape [rank=2, NNZ=2]: positions [0,1] and [1,0]
-        indices = _core.Tensor(np.array([[0, 1], [1, 0]], dtype=np.int64))
+        """as_tensor converts 2-D per-non-zero indices (ONNX layout [NNZ, rank]) to a dense array."""
+        values = _core.Tensor(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+        # Shape [NNZ=3, rank=2]: each row is the coordinate of one non-zero element
+        # NNZ 0 at (0, 1), NNZ 1 at (1, 0), NNZ 2 at (2, 2)
+        indices = _core.Tensor(np.array([[0, 1], [1, 0], [2, 2]], dtype=np.int64))
         sparse = ir.SparseTensor(values=values, indices=indices, dims=[3, 3])
         dense = sparse.as_tensor()
         expected = np.zeros((3, 3), dtype=np.float32)
         expected[0, 1] = 1.0
         expected[1, 0] = 2.0
+        expected[2, 2] = 3.0
         np.testing.assert_array_equal(dense.numpy(), expected)
 
     def test_as_tensor_lazy_returns_lazy_tensor(self):
@@ -3688,8 +3690,9 @@ class SparseTensorTest(unittest.TestCase):
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
-        values = _core.Tensor(np.array([1.0, 2.0], dtype=np.float32))
-        indices = _core.Tensor(np.array([[0, 1], [1, 0]], dtype=np.int64))
+        values = _core.Tensor(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+        # Shape [NNZ=3, rank=2]: each row is the coordinate of one non-zero (NNZ != rank)
+        indices = _core.Tensor(np.array([[0, 1], [1, 0], [2, 2]], dtype=np.int64))
         sparse = ir.SparseTensor(values=values, indices=indices, dims=[3, 3])
         result = sparse.numpy()
         self.assertIsInstance(result, sp.coo_array)
@@ -3697,6 +3700,7 @@ class SparseTensorTest(unittest.TestCase):
         expected_dense = np.zeros((3, 3), dtype=np.float32)
         expected_dense[0, 1] = 1.0
         expected_dense[1, 0] = 2.0
+        expected_dense[2, 2] = 3.0
         np.testing.assert_array_equal(result.toarray(), expected_dense)
 
     def test_numpy_1d_linear_indices(self):
@@ -3720,6 +3724,8 @@ class SparseTensorTest(unittest.TestCase):
         self.assertEqual(sparse.name, "test_sparse")
         self.assertEqual(sparse.dims, [3, 3])
         np.testing.assert_array_equal(sparse.values.numpy(), data)
+        # Indices shape is [NNZ, rank]: each row is one non-zero's coordinate
+        # NNZ 0 at (row=0, col=1), NNZ 1 at (row=1, col=0)
         np.testing.assert_array_equal(
             sparse.indices.numpy(), np.array([[0, 1], [1, 0]], dtype=np.int64)
         )
@@ -3744,6 +3750,58 @@ class SparseTensorTest(unittest.TestCase):
         data = np.array([3.0, 7.0], dtype=np.float64)
         original = sp.coo_array((data, ([0, 2], [1, 0])), shape=(4, 3))
         sparse = ir.SparseTensor.from_scipy_sparse(original)
+        roundtripped = sparse.numpy()
+        np.testing.assert_array_equal(roundtripped.toarray(), original.toarray())
+
+    def test_as_tensor_2d_indices_asymmetric_nnz_rank(self):
+        """as_tensor with 2-D [NNZ, rank] indices where NNZ != rank (validates correct layout)."""
+        # 4 non-zeros in a [5, 4] tensor: NNZ=4, rank=2
+        values = _core.Tensor(np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+        # Shape [NNZ=4, rank=2]: each row is a coordinate
+        indices = _core.Tensor(np.array([[0, 0], [1, 3], [3, 1], [4, 2]], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[5, 4])
+        dense = sparse.as_tensor()
+        expected = np.zeros((5, 4), dtype=np.float32)
+        expected[0, 0] = 1.0
+        expected[1, 3] = 2.0
+        expected[3, 1] = 3.0
+        expected[4, 2] = 4.0
+        np.testing.assert_array_equal(dense.numpy(), expected)
+
+    def test_numpy_2d_indices_asymmetric_nnz_rank(self):
+        """numpy() with 2-D [NNZ, rank] indices where NNZ != rank (validates correct layout)."""
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        # 4 non-zeros in a [5, 4] tensor: NNZ=4, rank=2
+        values = _core.Tensor(np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+        # Shape [NNZ=4, rank=2]: each row is a coordinate
+        indices = _core.Tensor(np.array([[0, 0], [1, 3], [3, 1], [4, 2]], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[5, 4])
+        result = sparse.numpy()
+        self.assertIsInstance(result, sp.coo_array)
+        expected = np.zeros((5, 4), dtype=np.float32)
+        expected[0, 0] = 1.0
+        expected[1, 3] = 2.0
+        expected[3, 1] = 3.0
+        expected[4, 2] = 4.0
+        np.testing.assert_array_equal(result.toarray(), expected)
+
+    def test_from_scipy_sparse_asymmetric_nnz_rank(self):
+        """from_scipy_sparse with NNZ != rank stores indices in [NNZ, rank] layout."""
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        # 4 non-zeros in a [5, 4] matrix: NNZ=4, rank=2
+        rows = [0, 1, 3, 4]
+        cols = [0, 3, 1, 2]
+        data = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        original = sp.coo_array((data, (rows, cols)), shape=(5, 4))
+        sparse = ir.SparseTensor.from_scipy_sparse(original)
+        self.assertEqual(sparse.dims, [5, 4])
+        # Indices must be [NNZ=4, rank=2]
+        self.assertEqual(sparse.indices.numpy().shape, (4, 2))
+        # Round-trip
         roundtripped = sparse.numpy()
         np.testing.assert_array_equal(roundtripped.toarray(), original.toarray())
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -3710,13 +3710,13 @@ class SparseTensorTest(unittest.TestCase):
         np.testing.assert_array_equal(result.toarray(), expected)
 
     def test_init_from_scipy_sparse(self):
-        """SparseTensor can be constructed from a scipy sparse array."""
+        """SparseTensor can be constructed via ir.tensor() from a scipy sparse array."""
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         data = np.array([1.0, 2.0], dtype=np.float32)
         coo = sp.coo_array((data, ([0, 1], [1, 0])), shape=(3, 3))
-        sparse = ir.SparseTensor(coo, name="test_sparse")
+        sparse = ir.tensor(coo, name="test_sparse")
         self.assertEqual(sparse.name, "test_sparse")
         self.assertEqual(sparse.dims, [3, 3])
         np.testing.assert_array_equal(sparse.values.numpy(), data)
@@ -3725,25 +3725,25 @@ class SparseTensorTest(unittest.TestCase):
         )
 
     def test_init_from_scipy_non_coo_format(self):
-        """SparseTensor construction from CSR and other scipy formats is supported."""
+        """ir.tensor() from CSR and other scipy formats is supported."""
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         csr = sp.eye(3, format="csr", dtype=np.float32)
-        sparse = ir.SparseTensor(csr)
+        sparse = ir.tensor(csr)
         self.assertEqual(sparse.dims, [3, 3])
         # Round-trip through numpy()
         result = sparse.numpy()
         np.testing.assert_array_equal(result.toarray(), np.eye(3, dtype=np.float32))
 
     def test_scipy_roundtrip(self):
-        """A scipy sparse array survives a SparseTensor round-trip."""
+        """A scipy sparse array survives a SparseTensor round-trip via ir.tensor()."""
         pytest.importorskip("scipy")
         import scipy.sparse as sp
 
         data = np.array([3.0, 7.0], dtype=np.float64)
         original = sp.coo_array((data, ([0, 2], [1, 0])), shape=(4, 3))
-        sparse = ir.SparseTensor(original)
+        sparse = ir.tensor(original)
         roundtripped = sparse.numpy()
         np.testing.assert_array_equal(roundtripped.toarray(), original.toarray())
 

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -17,6 +17,7 @@ import numpy as np
 import onnx
 import onnx.external_data_helper
 import parameterized
+import pytest
 import torch
 
 import onnx_ir as ir
@@ -3631,7 +3632,7 @@ class AttrTest(unittest.TestCase):
 
 
 class SparseTensorTest(unittest.TestCase):
-    """Tests for SparseTensor.as_tensor()."""
+    """Tests for SparseTensor.as_tensor() and SparseTensor.numpy()."""
 
     def test_as_tensor_1d_linear_indices(self):
         """as_tensor converts 1-D linear indices to a dense array."""
@@ -3681,6 +3682,70 @@ class SparseTensorTest(unittest.TestCase):
         dense = sparse.as_tensor()
         self.assertEqual(dense.dtype, ir.DataType.INT32)
         np.testing.assert_array_equal(dense.numpy(), [1, 0, 2, 0])
+
+    def test_numpy_returns_scipy_coo_array(self):
+        """numpy() returns a scipy.sparse.coo_array."""
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        values = _core.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        indices = _core.Tensor(np.array([[0, 1], [1, 0]], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[3, 3])
+        result = sparse.numpy()
+        self.assertIsInstance(result, sp.coo_array)
+        self.assertEqual(result.shape, (3, 3))
+        expected_dense = np.zeros((3, 3), dtype=np.float32)
+        expected_dense[0, 1] = 1.0
+        expected_dense[1, 0] = 2.0
+        np.testing.assert_array_equal(result.toarray(), expected_dense)
+
+    def test_numpy_1d_linear_indices(self):
+        """numpy() handles 1-D linear indices correctly."""
+        pytest.importorskip("scipy")
+        values = _core.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        indices = _core.Tensor(np.array([1, 3], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[2, 3])
+        result = sparse.numpy()
+        expected = np.array([[0.0, 1.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float32)
+        np.testing.assert_array_equal(result.toarray(), expected)
+
+    def test_init_from_scipy_sparse(self):
+        """SparseTensor can be constructed from a scipy sparse array."""
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        data = np.array([1.0, 2.0], dtype=np.float32)
+        coo = sp.coo_array((data, ([0, 1], [1, 0])), shape=(3, 3))
+        sparse = ir.SparseTensor(coo, name="test_sparse")
+        self.assertEqual(sparse.name, "test_sparse")
+        self.assertEqual(sparse.dims, [3, 3])
+        np.testing.assert_array_equal(sparse.values.numpy(), data)
+        np.testing.assert_array_equal(
+            sparse.indices.numpy(), np.array([[0, 1], [1, 0]], dtype=np.int64)
+        )
+
+    def test_init_from_scipy_non_coo_format(self):
+        """SparseTensor construction from CSR and other scipy formats is supported."""
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        csr = sp.eye(3, format="csr", dtype=np.float32)
+        sparse = ir.SparseTensor(csr)
+        self.assertEqual(sparse.dims, [3, 3])
+        # Round-trip through numpy()
+        result = sparse.numpy()
+        np.testing.assert_array_equal(result.toarray(), np.eye(3, dtype=np.float32))
+
+    def test_scipy_roundtrip(self):
+        """A scipy sparse array survives a SparseTensor round-trip."""
+        pytest.importorskip("scipy")
+        import scipy.sparse as sp
+
+        data = np.array([3.0, 7.0], dtype=np.float64)
+        original = sp.coo_array((data, ([0, 2], [1, 0])), shape=(4, 3))
+        sparse = ir.SparseTensor(original)
+        roundtripped = sparse.numpy()
+        np.testing.assert_array_equal(roundtripped.toarray(), original.toarray())
 
 
 class LazyTensorTest(unittest.TestCase):

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -3630,6 +3630,59 @@ class AttrTest(unittest.TestCase):
         self.assertTrue(attr.meta.is_valid("source_file"))
 
 
+class SparseTensorTest(unittest.TestCase):
+    """Tests for SparseTensor.as_tensor()."""
+
+    def test_as_tensor_1d_linear_indices(self):
+        """as_tensor converts 1-D linear indices to a dense array."""
+        values = _core.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        indices = _core.Tensor(np.array([1, 3], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[2, 3])
+        dense = sparse.as_tensor()
+        expected = np.array([[0.0, 1.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float32)
+        np.testing.assert_array_equal(dense.numpy(), expected)
+
+    def test_as_tensor_2d_per_dimension_indices(self):
+        """as_tensor converts 2-D per-dimension indices to a dense array."""
+        values = _core.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        # Shape [rank=2, NNZ=2]: positions [0,1] and [1,0]
+        indices = _core.Tensor(np.array([[0, 1], [1, 0]], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[3, 3])
+        dense = sparse.as_tensor()
+        expected = np.zeros((3, 3), dtype=np.float32)
+        expected[0, 1] = 1.0
+        expected[1, 0] = 2.0
+        np.testing.assert_array_equal(dense.numpy(), expected)
+
+    def test_as_tensor_lazy_returns_lazy_tensor(self):
+        """as_tensor(lazy=True) returns a LazyTensor with correct metadata."""
+        values = _core.Tensor(np.array([1.0], dtype=np.float32))
+        indices = _core.Tensor(np.array([0], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[3])
+        lazy = sparse.as_tensor(lazy=True)
+        self.assertIsInstance(lazy, _core.LazyTensor)
+        self.assertEqual(lazy.dtype, ir.DataType.FLOAT)
+        self.assertEqual(list(lazy.shape), [3])
+
+    def test_as_tensor_lazy_computes_correctly(self):
+        """LazyTensor returned by as_tensor(lazy=True) evaluates to the same dense array."""
+        values = _core.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        indices = _core.Tensor(np.array([1, 3], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[2, 3])
+        eager = sparse.as_tensor()
+        lazy = sparse.as_tensor(lazy=True)
+        np.testing.assert_array_equal(lazy.numpy(), eager.numpy())
+
+    def test_as_tensor_dtype_preserved(self):
+        """as_tensor preserves the dtype of the values tensor."""
+        values = _core.Tensor(np.array([1, 2], dtype=np.int32))
+        indices = _core.Tensor(np.array([0, 2], dtype=np.int64))
+        sparse = ir.SparseTensor(values=values, indices=indices, dims=[4])
+        dense = sparse.as_tensor()
+        self.assertEqual(dense.dtype, ir.DataType.INT32)
+        np.testing.assert_array_equal(dense.numpy(), [1, 0, 2, 0])
+
+
 class LazyTensorTest(unittest.TestCase):
     def test_lazy_tensor_initialization(self):
         def tensor_fn():

--- a/src/onnx_ir/_protocols.py
+++ b/src/onnx_ir/_protocols.py
@@ -187,7 +187,7 @@ class ValueProtocol(Protocol):
     metadata_props: MutableMapping[str, str]
     meta: MutableMapping[str, Any]
     doc_string: str | None
-    const_value: TensorProtocol | None
+    const_value: TensorProtocol | SparseTensorProtocol | None
 
     def producer(self) -> NodeProtocol | None:
         """The node that produces this value."""

--- a/src/onnx_ir/_protocols.py
+++ b/src/onnx_ir/_protocols.py
@@ -465,6 +465,7 @@ class ReferenceAttributeProtocol(Protocol):
 
 @typing.runtime_checkable
 class SparseTensorProtocol(Protocol):
+    name: str | None
     values: TensorProtocol
     indices: TensorProtocol
     dims: Sequence[int]

--- a/src/onnx_ir/_protocols.py
+++ b/src/onnx_ir/_protocols.py
@@ -178,7 +178,8 @@ class ValueProtocol(Protocol):
         metadata_props: Metadata that will be serialized to the ONNX file.
         meta: Metadata store for graph transform passes.
         doc_string: Documentation string.
-        const_value: The constant tensor is the value constant.
+        const_value: The constant dense tensor when the value is constant.
+        const_sparse_value: The constant sparse tensor when the value is a sparse constant.
     """
 
     name: str
@@ -187,7 +188,8 @@ class ValueProtocol(Protocol):
     metadata_props: MutableMapping[str, str]
     meta: MutableMapping[str, Any]
     doc_string: str | None
-    const_value: TensorProtocol | SparseTensorProtocol | None
+    const_value: TensorProtocol | None
+    const_sparse_value: SparseTensorProtocol | None
 
     def producer(self) -> NodeProtocol | None:
         """The node that produces this value."""

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1954,7 +1954,10 @@ def serialize_graph_into(
             serialize_tensor_into(graph_proto.initializer.add(), from_=value.const_value)
         else:
             # Skip initializers without constant values
-            logger.warning("Initializer '%s' does not have a constant value set.", value.name)
+            if not isinstance(value.type, _core.SparseTensorType):
+                logger.warning(
+                    "Initializer '%s' does not have a constant value set.", value.name
+                )
     for node in from_:
         serialize_node_into(
             graph_proto.node.add(), from_=node, model_ir_version=model_ir_version

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -32,6 +32,7 @@ __all__ = [
     "deserialize_node",
     "deserialize_node_device_configuration",
     "deserialize_opset_import",
+    "deserialize_sparse_tensor",
     "deserialize_tensor",
     "deserialize_tensor_shape",
     "deserialize_type_proto_for_shape",
@@ -56,6 +57,8 @@ __all__ = [
     "serialize_shape_into",
     "serialize_reference_attribute_into",
     "serialize_reference_attribute",
+    "serialize_sparse_tensor_into",
+    "serialize_sparse_tensor",
     "serialize_tensor_into",
     "serialize_tensor",
     "serialize_type_into",
@@ -132,6 +135,8 @@ def from_proto(proto: onnx.NodeProto) -> _core.Node: ...  # type: ignore[overloa
 @typing.overload
 def from_proto(proto: onnx.TensorProto) -> _protocols.TensorProtocol: ...  # type: ignore[overload-overlap]
 @typing.overload
+def from_proto(proto: onnx.SparseTensorProto) -> _core.SparseTensor: ...  # type: ignore[overload-overlap]
+@typing.overload
 def from_proto(proto: onnx.AttributeProto) -> _core.Attr: ...  # type: ignore[overload-overlap]
 @typing.overload
 def from_proto(proto: onnx.ValueInfoProto) -> _core.Value: ...  # type: ignore[overload-overlap]
@@ -161,6 +166,8 @@ def from_proto(proto: object) -> object:
         return deserialize_node(proto)
     if isinstance(proto, onnx.TensorProto):
         return deserialize_tensor(proto)
+    if isinstance(proto, onnx.SparseTensorProto):
+        return deserialize_sparse_tensor(proto)
     if isinstance(proto, onnx.AttributeProto):
         return deserialize_attribute(proto)
     if isinstance(proto, onnx.ValueInfoProto):
@@ -264,6 +271,8 @@ def to_proto(ir_object: _protocols.NodeProtocol) -> onnx.NodeProto: ...  # type:
 @typing.overload
 def to_proto(ir_object: _protocols.TensorProtocol) -> onnx.TensorProto: ...  # type: ignore[overload-overlap]
 @typing.overload
+def to_proto(ir_object: _protocols.SparseTensorProtocol) -> onnx.SparseTensorProto: ...  # type: ignore[overload-overlap]
+@typing.overload
 def to_proto(ir_object: _protocols.AttributeProtocol) -> onnx.AttributeProto: ...  # type: ignore[overload-overlap]
 @typing.overload
 def to_proto(ir_object: _protocols.ReferenceAttributeProtocol) -> onnx.AttributeProto: ...  # type: ignore[overload-overlap]
@@ -287,6 +296,8 @@ def to_proto(ir_object: object) -> object:
         return serialize_node(ir_object)
     if isinstance(ir_object, _protocols.TensorProtocol):
         return serialize_tensor(ir_object)
+    if isinstance(ir_object, _protocols.SparseTensorProtocol):
+        return serialize_sparse_tensor(ir_object)
     if isinstance(ir_object, _protocols.ValueProtocol):
         return serialize_value(ir_object)
     if isinstance(ir_object, _protocols.AttributeProtocol) and not ir_object.is_ref():
@@ -836,6 +847,41 @@ def _deserialize_graph(
             values[initializer_name] = initializer_value
         initializer_values.append(initializer_value)
 
+    # Create values for sparse initializers
+    sparse_initializer_tensors = [
+        deserialize_sparse_tensor(tensor) for tensor in proto.sparse_initializer
+    ]
+    for i, sparse_tensor in enumerate(sparse_initializer_tensors):
+        initializer_name = sparse_tensor.name
+        if not initializer_name:
+            logger.warning(
+                "Sparse initializer tensor must have a name but the %s-th sparse initializer does not. Skipping this initializer.",
+                i,
+            )
+            continue
+        if initializer_name in values:
+            # The sparse initializer is for an existing value (e.g., an input)
+            initializer_value = values[initializer_name]
+            initializer_value.const_value = sparse_tensor
+        else:
+            # The sparse initializer is for a new value. Create the value first
+            initializer_value = _core.Value(
+                None,
+                index=None,
+                name=initializer_name,
+                type=_core.SparseTensorType(_enums.DataType(sparse_tensor.values.dtype)),
+                shape=_core.Shape(sparse_tensor.dims),
+                const_value=sparse_tensor,
+            )
+            if initializer_name in value_info:
+                deserialize_value_info_proto(value_info[initializer_name], initializer_value)
+            if initializer_value.name in quantization_annotations:
+                _deserialize_quantization_annotation(
+                    quantization_annotations[initializer_value.name], initializer_value
+                )
+            values[initializer_name] = initializer_value
+        initializer_values.append(initializer_value)
+
     # Declare values for all node outputs from this graph scope. This is necessary
     # to handle the case where a node in a subgraph uses a value that is declared out
     # of order in the outer graph. Declaring the values first allows us to find the
@@ -1179,6 +1225,21 @@ def deserialize_tensor(
     return TensorProtoTensor(proto)
 
 
+def deserialize_sparse_tensor(proto: onnx.SparseTensorProto) -> _core.SparseTensor:
+    """Deserialize an ONNX SparseTensorProto into an IR SparseTensor.
+
+    Args:
+        proto: The ONNX SparseTensorProto to deserialize.
+
+    Returns:
+        An :class:`onnx_ir.SparseTensor` representing the sparse tensor.
+    """
+    values = deserialize_tensor(proto.values)
+    indices = deserialize_tensor(proto.indices)
+    dims = list(proto.dims)
+    return _core.SparseTensor(values, indices, dims)
+
+
 def deserialize_metadata_props(
     proto: Sequence[onnx.StringStringEntryProto],
 ) -> dict[str, str] | None:
@@ -1259,12 +1320,14 @@ def _deserialize_attribute(
             doc_string=doc_string,
         )
     if type_ == _enums.AttributeType.SPARSE_TENSOR:
-        raise NotImplementedError(
-            f"Sparse tensors are not supported yet. {_PLEASE_CONTRIBUTE}"
+        return _core.AttrSparseTensor(
+            name, deserialize_sparse_tensor(proto.sparse_tensor), doc_string=doc_string
         )
     if type_ == _enums.AttributeType.SPARSE_TENSORS:
-        raise NotImplementedError(
-            f"Sparse tensors are not supported yet. {_PLEASE_CONTRIBUTE}"
+        return _core.AttrSparseTensors(
+            name,
+            [deserialize_sparse_tensor(st) for st in proto.sparse_tensors],
+            doc_string=doc_string,
         )
     if type_ == _enums.AttributeType.TYPE_PROTO:
         ir_type = deserialize_type_proto_for_type(proto.tp)
@@ -1868,7 +1931,6 @@ def serialize_graph_into(
             # Annotations for initializers will be added below to avoid double adding
             _maybe_add_quantization_annotation(graph_proto, input_)
     input_names = {input_.name for input_ in from_.inputs}
-    # TODO(justinchuby): Support sparse_initializer
     for value in from_.initializers.values():
         _maybe_add_quantization_annotation(graph_proto, value)
         if _should_create_value_info_for_value(value) and value.name not in input_names:
@@ -1880,8 +1942,14 @@ def serialize_graph_into(
             logger.warning("Initializer '%s' does not have a constant value set.", value.name)
             continue
         # Make sure the tensor's name is the same as the value's name
-        value.const_value.name = value.name
-        serialize_tensor_into(graph_proto.initializer.add(), from_=value.const_value)
+        if isinstance(value.const_value, _protocols.SparseTensorProtocol):
+            # Serialize sparse initializers into sparse_initializer
+            if hasattr(value.const_value, "name"):
+                value.const_value.name = value.name  # type: ignore[assignment]
+            serialize_sparse_tensor_into(graph_proto.sparse_initializer.add(), from_=value.const_value)
+        else:
+            value.const_value.name = value.name
+            serialize_tensor_into(graph_proto.initializer.add(), from_=value.const_value)
     for node in from_:
         serialize_node_into(
             graph_proto.node.add(), from_=node, model_ir_version=model_ir_version
@@ -2144,6 +2212,38 @@ def serialize_tensor_into(
     _serialize_metadata_props_into(tensor_proto.metadata_props, from_.metadata_props)
 
 
+def serialize_sparse_tensor(
+    sparse_tensor: _protocols.SparseTensorProtocol,
+) -> onnx.SparseTensorProto:
+    """Serialize a sparse tensor to an ONNX SparseTensorProto.
+
+    Args:
+        sparse_tensor: The sparse tensor to serialize.
+
+    Returns:
+        The serialized ONNX SparseTensorProto object.
+    """
+    sparse_tensor_proto = onnx.SparseTensorProto()
+    serialize_sparse_tensor_into(sparse_tensor_proto, from_=sparse_tensor)
+    return sparse_tensor_proto
+
+
+@_capture_errors(lambda sparse_tensor_proto, from_: repr(from_))
+def serialize_sparse_tensor_into(
+    sparse_tensor_proto: onnx.SparseTensorProto,
+    from_: _protocols.SparseTensorProtocol,
+) -> None:
+    """Serialize a sparse tensor into an ONNX SparseTensorProto in-place.
+
+    Args:
+        sparse_tensor_proto: The proto to serialize into.
+        from_: The sparse tensor to serialize.
+    """
+    serialize_tensor_into(sparse_tensor_proto.values, from_.values)
+    serialize_tensor_into(sparse_tensor_proto.indices, from_.indices)
+    sparse_tensor_proto.dims.extend(from_.dims)
+
+
 def serialize_attribute(attribute: _protocols.AttributeProtocol) -> onnx.AttributeProto:
     """Serialize an IR Attribute to an ONNX AttributeProto.
 
@@ -2225,13 +2325,14 @@ def _fill_in_value_for_attribute(
             serialize_graph_into(attribute_proto.graphs.add(), graph)
         attribute_proto.type = onnx.AttributeProto.GRAPHS
     elif type_ == _enums.AttributeType.SPARSE_TENSOR:
-        raise NotImplementedError(
-            f"Sparse tensors are not supported yet. {_PLEASE_CONTRIBUTE}"
-        )
+        # value: _protocols.SparseTensorProtocol
+        serialize_sparse_tensor_into(attribute_proto.sparse_tensor, value)
+        attribute_proto.type = onnx.AttributeProto.SPARSE_TENSOR
     elif type_ == _enums.AttributeType.SPARSE_TENSORS:
-        raise NotImplementedError(
-            f"Sparse tensors are not supported yet. {_PLEASE_CONTRIBUTE}"
-        )
+        # value: Sequence[_protocols.SparseTensorProtocol]
+        for sparse_tensor in value:
+            serialize_sparse_tensor_into(attribute_proto.sparse_tensors.add(), sparse_tensor)
+        attribute_proto.type = onnx.AttributeProto.SPARSE_TENSORS
     elif type_ == _enums.AttributeType.TYPE_PROTO:
         # value: _core.TypeAndShape
         if value.type is not None:

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1944,8 +1944,7 @@ def serialize_graph_into(
         # Make sure the tensor's name is the same as the value's name
         if isinstance(value.const_value, _protocols.SparseTensorProtocol):
             # Serialize sparse initializers into sparse_initializer
-            if hasattr(value.const_value, "name"):
-                value.const_value.name = value.name  # type: ignore[assignment]
+            value.const_value.name = value.name
             serialize_sparse_tensor_into(graph_proto.sparse_initializer.add(), from_=value.const_value)
         else:
             value.const_value.name = value.name

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -1947,7 +1947,9 @@ def serialize_graph_into(
         if value.const_sparse_value is not None:
             # Serialize sparse initializers into sparse_initializer
             value.const_sparse_value.name = value.name
-            serialize_sparse_tensor_into(graph_proto.sparse_initializer.add(), from_=value.const_sparse_value)
+            serialize_sparse_tensor_into(
+                graph_proto.sparse_initializer.add(), from_=value.const_sparse_value
+            )
         elif value.const_value is not None:
             # Make sure the tensor's name is the same as the value's name
             value.const_value.name = value.name

--- a/src/onnx_ir/serde.py
+++ b/src/onnx_ir/serde.py
@@ -862,7 +862,14 @@ def _deserialize_graph(
         if initializer_name in values:
             # The sparse initializer is for an existing value (e.g., an input)
             initializer_value = values[initializer_name]
-            initializer_value.const_value = sparse_tensor
+            initializer_value.const_sparse_value = sparse_tensor
+            if initializer_name in value_info:
+                deserialize_value_info_proto(value_info[initializer_name], initializer_value)
+            if initializer_value.name in quantization_annotations:
+                _deserialize_quantization_annotation(
+                    quantization_annotations[initializer_value.name], initializer_value
+                )
+            values[initializer_name] = initializer_value
         else:
             # The sparse initializer is for a new value. Create the value first
             initializer_value = _core.Value(
@@ -871,7 +878,7 @@ def _deserialize_graph(
                 name=initializer_name,
                 type=_core.SparseTensorType(_enums.DataType(sparse_tensor.values.dtype)),
                 shape=_core.Shape(sparse_tensor.dims),
-                const_value=sparse_tensor,
+                const_sparse_value=sparse_tensor,
             )
             if initializer_name in value_info:
                 deserialize_value_info_proto(value_info[initializer_name], initializer_value)
@@ -1937,18 +1944,17 @@ def serialize_graph_into(
             # Serialize information about all initializers into value_info,
             # except for those that are also graph inputs
             serialize_value_into(graph_proto.value_info.add(), value)
-        if value.const_value is None:
-            # Skip initializers without constant values
-            logger.warning("Initializer '%s' does not have a constant value set.", value.name)
-            continue
-        # Make sure the tensor's name is the same as the value's name
-        if isinstance(value.const_value, _protocols.SparseTensorProtocol):
+        if value.const_sparse_value is not None:
             # Serialize sparse initializers into sparse_initializer
-            value.const_value.name = value.name
-            serialize_sparse_tensor_into(graph_proto.sparse_initializer.add(), from_=value.const_value)
-        else:
+            value.const_sparse_value.name = value.name
+            serialize_sparse_tensor_into(graph_proto.sparse_initializer.add(), from_=value.const_sparse_value)
+        elif value.const_value is not None:
+            # Make sure the tensor's name is the same as the value's name
             value.const_value.name = value.name
             serialize_tensor_into(graph_proto.initializer.add(), from_=value.const_value)
+        else:
+            # Skip initializers without constant values
+            logger.warning("Initializer '%s' does not have a constant value set.", value.name)
     for node in from_:
         serialize_node_into(
             graph_proto.node.add(), from_=node, model_ir_version=model_ir_version

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -1467,7 +1467,9 @@ class SparseTensorTest(unittest.TestCase):
 
     def _make_sparse_tensor_proto(self, name: str = "my_sparse") -> onnx.SparseTensorProto:
         """Create a simple SparseTensorProto for testing."""
-        values_proto = onnx.helper.make_tensor("", onnx.TensorProto.FLOAT, [3], [1.0, 2.0, 3.0])
+        values_proto = onnx.helper.make_tensor(
+            "", onnx.TensorProto.FLOAT, [3], [1.0, 2.0, 3.0]
+        )
         indices_proto = onnx.helper.make_tensor("", onnx.TensorProto.INT64, [3], [0, 2, 5])
         sparse_proto = onnx.helper.make_sparse_tensor(values_proto, indices_proto, [6])
         sparse_proto.values.name = name
@@ -1519,7 +1521,9 @@ class SparseTensorTest(unittest.TestCase):
     def test_sparse_tensor_attribute_roundtrip(self):
         proto = self._make_sparse_tensor_proto()
         sparse = serde.deserialize_sparse_tensor(proto)
-        node = ir.Node("", "TestOp", [], attributes=[ir.AttrSparseTensor("sparse_attr", sparse)])
+        node = ir.Node(
+            "", "TestOp", [], attributes=[ir.AttrSparseTensor("sparse_attr", sparse)]
+        )
         node_proto = serde.serialize_node(node)
         restored = serde.deserialize_node(node_proto)
         attr = restored.attributes["sparse_attr"]
@@ -1534,7 +1538,10 @@ class SparseTensorTest(unittest.TestCase):
         sparse1 = serde.deserialize_sparse_tensor(proto1)
         sparse2 = serde.deserialize_sparse_tensor(proto2)
         node = ir.Node(
-            "", "TestOp", [], attributes=[ir.AttrSparseTensors("sparse_attrs", [sparse1, sparse2])]
+            "",
+            "TestOp",
+            [],
+            attributes=[ir.AttrSparseTensors("sparse_attrs", [sparse1, sparse2])],
         )
         node_proto = serde.serialize_node(node)
         restored = serde.deserialize_node(node_proto)
@@ -1548,7 +1555,11 @@ class SparseTensorTest(unittest.TestCase):
                 [],
                 "test_graph",
                 [],
-                [onnx.helper.make_tensor_value_info("sparse_val", onnx.TensorProto.FLOAT, None)],
+                [
+                    onnx.helper.make_tensor_value_info(
+                        "sparse_val", onnx.TensorProto.FLOAT, None
+                    )
+                ],
             ),
             opset_imports=[onnx.helper.make_opsetid("", 17)],
         )
@@ -1567,7 +1578,11 @@ class SparseTensorTest(unittest.TestCase):
                 [],
                 "test_graph",
                 [],
-                [onnx.helper.make_tensor_value_info("sparse_val", onnx.TensorProto.FLOAT, None)],
+                [
+                    onnx.helper.make_tensor_value_info(
+                        "sparse_val", onnx.TensorProto.FLOAT, None
+                    )
+                ],
             ),
             opset_imports=[onnx.helper.make_opsetid("", 17)],
         )
@@ -1638,7 +1653,11 @@ class SparseTensorTest(unittest.TestCase):
         with self.assertLogs("onnx_ir.serde", level="WARNING") as log_ctx:
             serde.serialize_model(model)
         warning_msgs = [r for r in log_ctx.output if "constant value" in r]
-        self.assertGreater(len(warning_msgs), 0, "Expected a warning for dense initializer without const_value")
+        self.assertGreater(
+            len(warning_msgs),
+            0,
+            "Expected a warning for dense initializer without const_value",
+        )
 
 
 if __name__ == "__main__":

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -1505,6 +1505,37 @@ class SparseTensorTest(unittest.TestCase):
         )
         self.assertEqual(list(result_proto.dims), [6])
 
+    def test_sparse_tensor_roundtrip_2d_indices_asymmetric(self):
+        """Round-trip with 2-D [NNZ, rank] indices where NNZ != rank."""
+        # Build a SparseTensorProto with 2-D indices: shape [NNZ=4, rank=2] per ONNX spec
+        # Non-zeros at (0,0)=1, (1,3)=2, (3,1)=3, (4,2)=4 in a [5,4] tensor
+        values_proto = onnx.helper.make_tensor(
+            "", onnx.TensorProto.FLOAT, [4], [1.0, 2.0, 3.0, 4.0]
+        )
+        # ONNX 2-D indices layout: [NNZ=4, rank=2]
+        indices_flat = [0, 0, 1, 3, 3, 1, 4, 2]
+        indices_proto = onnx.helper.make_tensor(
+            "", onnx.TensorProto.INT64, [4, 2], indices_flat
+        )
+        proto = onnx.helper.make_sparse_tensor(values_proto, indices_proto, [5, 4])
+        proto.values.name = "sparse_2d"
+
+        # Deserialize → SparseTensor
+        sparse = serde.deserialize_sparse_tensor(proto)
+        self.assertEqual(sparse.dims, [5, 4])
+        np.testing.assert_array_equal(sparse.indices.numpy().shape, (4, 2))
+
+        # Re-serialize and compare
+        result_proto = serde.serialize_sparse_tensor(sparse)
+        np.testing.assert_array_equal(
+            onnx.numpy_helper.to_array(result_proto.values), [1.0, 2.0, 3.0, 4.0]
+        )
+        np.testing.assert_array_equal(
+            onnx.numpy_helper.to_array(result_proto.indices),
+            np.array([[0, 0], [1, 3], [3, 1], [4, 2]], dtype=np.int64),
+        )
+        self.assertEqual(list(result_proto.dims), [5, 4])
+
     def test_from_proto_sparse_tensor(self):
         proto = self._make_sparse_tensor_proto()
         result = ir.from_proto(proto)

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -1601,6 +1601,45 @@ class SparseTensorTest(unittest.TestCase):
         value = ir.Value(name="w", const_sparse_value=sparse)
         self.assertIsInstance(value.const_sparse_value, ir.SparseTensor)
 
+    def test_serializer_no_warning_for_sparse_initializer_without_const_value(self):
+        """Serializer should not warn when a sparse-typed initializer has no const_sparse_value."""
+        v = ir.Value(
+            None,
+            index=None,
+            name="sparse_x",
+            type=ir.SparseTensorType(ir.DataType.FLOAT),
+            shape=ir.Shape([3, 3]),
+        )
+        graph = ir.Graph(inputs=[], outputs=[], nodes=[], name="test")
+        graph.initializers["sparse_x"] = v
+        model = ir.Model(graph, ir_version=8)
+        with self.assertLogs("onnx_ir.serde", level="WARNING") as log_ctx:
+            # Generate an unrelated warning so assertLogs doesn't raise on no warnings
+            import logging
+
+            logging.getLogger("onnx_ir.serde").warning("sentinel")
+            serde.serialize_model(model)
+        # Only the sentinel warning should appear, not the "constant value" warning
+        warning_msgs = [r for r in log_ctx.output if "constant value" in r]
+        self.assertEqual(warning_msgs, [], "Unexpected warning for sparse-typed initializer")
+
+    def test_serializer_warns_for_dense_initializer_without_const_value(self):
+        """Serializer should warn when a dense-typed initializer has no const_value."""
+        v = ir.Value(
+            None,
+            index=None,
+            name="dense_x",
+            type=ir.TensorType(ir.DataType.FLOAT),
+            shape=ir.Shape([3]),
+        )
+        graph = ir.Graph(inputs=[], outputs=[], nodes=[], name="test")
+        graph.initializers["dense_x"] = v
+        model = ir.Model(graph, ir_version=8)
+        with self.assertLogs("onnx_ir.serde", level="WARNING") as log_ctx:
+            serde.serialize_model(model)
+        warning_msgs = [r for r in log_ctx.output if "constant value" in r]
+        self.assertGreater(len(warning_msgs), 0, "Expected a warning for dense initializer without const_value")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -1558,8 +1558,8 @@ class SparseTensorTest(unittest.TestCase):
         model = serde.deserialize_model(model_proto)
         self.assertIn("sparse_val", model.graph.initializers)
         sparse_init = model.graph.initializers["sparse_val"]
-        self.assertIsInstance(sparse_init.const_value, ir.SparseTensor)
-        self.assertEqual(sparse_init.const_value.dims, [6])
+        self.assertIsInstance(sparse_init.const_sparse_value, ir.SparseTensor)
+        self.assertEqual(sparse_init.const_sparse_value.dims, [6])
 
     def test_graph_with_sparse_initializer_serialization(self):
         model_proto = onnx.helper.make_model(
@@ -1598,8 +1598,8 @@ class SparseTensorTest(unittest.TestCase):
     def test_value_with_sparse_const_value(self):
         sparse_proto = self._make_sparse_tensor_proto("w")
         sparse = serde.deserialize_sparse_tensor(sparse_proto)
-        value = ir.Value(name="w", const_value=sparse)
-        self.assertIsInstance(value.const_value, ir.SparseTensor)
+        value = ir.Value(name="w", const_sparse_value=sparse)
+        self.assertIsInstance(value.const_sparse_value, ir.SparseTensor)
 
 
 if __name__ == "__main__":

--- a/src/onnx_ir/serde_test.py
+++ b/src/onnx_ir/serde_test.py
@@ -1462,5 +1462,145 @@ class ValueInfoSerializationTest(unittest.TestCase):
         self.assertGreater(len(proto.metadata_props), 0)
 
 
+class SparseTensorTest(unittest.TestCase):
+    """Tests for SparseTensor serialization and deserialization."""
+
+    def _make_sparse_tensor_proto(self, name: str = "my_sparse") -> onnx.SparseTensorProto:
+        """Create a simple SparseTensorProto for testing."""
+        values_proto = onnx.helper.make_tensor("", onnx.TensorProto.FLOAT, [3], [1.0, 2.0, 3.0])
+        indices_proto = onnx.helper.make_tensor("", onnx.TensorProto.INT64, [3], [0, 2, 5])
+        sparse_proto = onnx.helper.make_sparse_tensor(values_proto, indices_proto, [6])
+        sparse_proto.values.name = name
+        return sparse_proto
+
+    def test_deserialize_sparse_tensor(self):
+        proto = self._make_sparse_tensor_proto()
+        result = serde.deserialize_sparse_tensor(proto)
+        self.assertIsInstance(result, ir.SparseTensor)
+        self.assertEqual(result.name, "my_sparse")
+        self.assertEqual(result.dims, [6])
+        self.assertEqual(result.values.size, 3)
+        self.assertEqual(result.indices.size, 3)
+
+    def test_serialize_sparse_tensor(self):
+        proto = self._make_sparse_tensor_proto()
+        sparse = serde.deserialize_sparse_tensor(proto)
+        result_proto = serde.serialize_sparse_tensor(sparse)
+        self.assertIsInstance(result_proto, onnx.SparseTensorProto)
+        self.assertEqual(list(result_proto.dims), [6])
+        self.assertEqual(result_proto.values.name, "my_sparse")
+
+    def test_sparse_tensor_roundtrip(self):
+        proto = self._make_sparse_tensor_proto()
+        sparse = serde.deserialize_sparse_tensor(proto)
+        result_proto = serde.serialize_sparse_tensor(sparse)
+        # Check that values are preserved
+        np.testing.assert_array_equal(
+            onnx.numpy_helper.to_array(result_proto.values), [1.0, 2.0, 3.0]
+        )
+        np.testing.assert_array_equal(
+            onnx.numpy_helper.to_array(result_proto.indices), [0, 2, 5]
+        )
+        self.assertEqual(list(result_proto.dims), [6])
+
+    def test_from_proto_sparse_tensor(self):
+        proto = self._make_sparse_tensor_proto()
+        result = ir.from_proto(proto)
+        self.assertIsInstance(result, ir.SparseTensor)
+        self.assertEqual(result.name, "my_sparse")
+
+    def test_to_proto_sparse_tensor(self):
+        proto = self._make_sparse_tensor_proto()
+        sparse = serde.deserialize_sparse_tensor(proto)
+        result = ir.to_proto(sparse)
+        self.assertIsInstance(result, onnx.SparseTensorProto)
+        self.assertEqual(list(result.dims), [6])
+
+    def test_sparse_tensor_attribute_roundtrip(self):
+        proto = self._make_sparse_tensor_proto()
+        sparse = serde.deserialize_sparse_tensor(proto)
+        node = ir.Node("", "TestOp", [], attributes=[ir.AttrSparseTensor("sparse_attr", sparse)])
+        node_proto = serde.serialize_node(node)
+        restored = serde.deserialize_node(node_proto)
+        attr = restored.attributes["sparse_attr"]
+        self.assertEqual(attr.type, ir.AttributeType.SPARSE_TENSOR)
+        restored_sparse = attr.value
+        self.assertIsInstance(restored_sparse, ir.SparseTensor)
+        self.assertEqual(restored_sparse.dims, [6])
+
+    def test_sparse_tensors_attribute_roundtrip(self):
+        proto1 = self._make_sparse_tensor_proto("sparse1")
+        proto2 = self._make_sparse_tensor_proto("sparse2")
+        sparse1 = serde.deserialize_sparse_tensor(proto1)
+        sparse2 = serde.deserialize_sparse_tensor(proto2)
+        node = ir.Node(
+            "", "TestOp", [], attributes=[ir.AttrSparseTensors("sparse_attrs", [sparse1, sparse2])]
+        )
+        node_proto = serde.serialize_node(node)
+        restored = serde.deserialize_node(node_proto)
+        attr = restored.attributes["sparse_attrs"]
+        self.assertEqual(attr.type, ir.AttributeType.SPARSE_TENSORS)
+        self.assertEqual(len(attr.value), 2)
+
+    def test_graph_with_sparse_initializer_deserialization(self):
+        model_proto = onnx.helper.make_model(
+            onnx.helper.make_graph(
+                [],
+                "test_graph",
+                [],
+                [onnx.helper.make_tensor_value_info("sparse_val", onnx.TensorProto.FLOAT, None)],
+            ),
+            opset_imports=[onnx.helper.make_opsetid("", 17)],
+        )
+        sparse_proto = self._make_sparse_tensor_proto("sparse_val")
+        model_proto.graph.sparse_initializer.append(sparse_proto)
+
+        model = serde.deserialize_model(model_proto)
+        self.assertIn("sparse_val", model.graph.initializers)
+        sparse_init = model.graph.initializers["sparse_val"]
+        self.assertIsInstance(sparse_init.const_value, ir.SparseTensor)
+        self.assertEqual(sparse_init.const_value.dims, [6])
+
+    def test_graph_with_sparse_initializer_serialization(self):
+        model_proto = onnx.helper.make_model(
+            onnx.helper.make_graph(
+                [],
+                "test_graph",
+                [],
+                [onnx.helper.make_tensor_value_info("sparse_val", onnx.TensorProto.FLOAT, None)],
+            ),
+            opset_imports=[onnx.helper.make_opsetid("", 17)],
+        )
+        sparse_proto = self._make_sparse_tensor_proto("sparse_val")
+        model_proto.graph.sparse_initializer.append(sparse_proto)
+
+        model = serde.deserialize_model(model_proto)
+        result_proto = serde.serialize_model(model)
+        self.assertEqual(len(result_proto.graph.sparse_initializer), 1)
+        sp = result_proto.graph.sparse_initializer[0]
+        self.assertEqual(sp.values.name, "sparse_val")
+        self.assertEqual(list(sp.dims), [6])
+
+    def test_sparse_tensor_name_property(self):
+        sparse_proto = self._make_sparse_tensor_proto("test_name")
+        sparse = serde.deserialize_sparse_tensor(sparse_proto)
+        self.assertEqual(sparse.name, "test_name")
+        # Test name setter
+        sparse.name = "new_name"
+        self.assertEqual(sparse.name, "new_name")
+        self.assertEqual(sparse.values.name, "new_name")
+
+    def test_sparse_tensor_is_sparse_tensor_protocol(self):
+        sparse_proto = self._make_sparse_tensor_proto()
+        sparse = serde.deserialize_sparse_tensor(sparse_proto)
+        self.assertIsInstance(sparse, ir.SparseTensorProtocol)
+
+    def test_value_with_sparse_const_value(self):
+        sparse_proto = self._make_sparse_tensor_proto("w")
+        sparse = serde.deserialize_sparse_tensor(sparse_proto)
+        value = ir.Value(name="w", const_value=sparse)
+        self.assertIsInstance(value.const_value, ir.SparseTensor)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds first-class support for sparse tensors in the ONNX IR, including a new `SparseTensor` class (COO format following `SparseTensorProto`), serde support, sparse initializers, and sparse-tensor attributes.

This continues the work from #426 with a refined API.

### Sparse tensor support
- New `SparseTensor` class in `_core.py` storing `values`, `indices`, and `dims` (COO format), with `numpy()` (→ `scipy.sparse.coo_array`) and `as_tensor(lazy=)` (→ dense `Tensor`) conversions.
- `SparseTensor.from_scipy_sparse()` classmethod to construct from any `scipy.sparse` array (converted to COO). `ir.tensor()` stays dense-only with a clean `TensorProtocol` return type.
- `Value.const_sparse_value` field for sparse initializers, with correct name propagation and string representation.
- Serde: `serialize_sparse_tensor`/`serialize_sparse_tensor_into`/`deserialize_sparse_tensor`, sparse initializer (de)serialization, and `SPARSE_TENSOR`/`SPARSE_TENSORS` attribute handling.
- `SparseTensorProtocol` added to `_protocols.py`.

### Design notes
- `SparseTensor` intentionally has no `doc_string`/`metadata_props` because `SparseTensorProto` only stores `values`/`indices`/`dims`; `meta` is available for in-memory analysis (not serialized).

### Public API & docs
- Exposes `SparseTensor`, `AttrSparseTensor`, `AttrSparseTensors`, and the new serde functions.
- Documents sparse tensor usage in `docs/tensors.md`.

### Testing
- Comprehensive tests for construction, conversion, round-tripping, initializers, and attributes.