### PR TITLE
docs: expand user guides and IR documentation

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,5 +1,8 @@
 # onnx_ir
 
+See [Introduction to the IR](../ir.md) for the object model and
+[Constructing models](../model_construction.md) for end-to-end examples.
+
 ```{eval-rst}
 .. automodule::onnx_ir
 ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,9 @@
 # IR APIs
 
+Start with [Introduction to the IR](../ir.md) and the
+[documentation home](../index.md) for conceptual and task-oriented
+documentation.
+
 ```{toctree}
 :maxdepth: 1
 

--- a/docs/api/ir_analysis.md
+++ b/docs/api/ir_analysis.md
@@ -1,7 +1,10 @@
 # onnx_ir.analysis
 
+See [Subgraphs and functions](../subgraphs_and_functions.md) for implicit-capture
+analysis in nested graphs.
+
 ```{eval-rst}
-.. automodule:: onnx_ir.analysis
+.. automodule::onnx_ir.analysis
 .. currentmodule:: onnx_ir.analysis
 ```
 

--- a/docs/api/ir_convenience.md
+++ b/docs/api/ir_convenience.md
@@ -1,5 +1,8 @@
 # onnx_ir.convenience
 
+See [Graph transformation patterns](../graph_transformations.md) for rewiring,
+renaming, extraction, and safe removal examples.
+
 ```{eval-rst}
 .. automodule::onnx_ir.convenience
 .. currentmodule:: onnx_ir.convenience

--- a/docs/api/ir_external_data.md
+++ b/docs/api/ir_external_data.md
@@ -17,4 +17,6 @@ The `onnx_ir.external_data` module provides utilities for handling external data
 .. autofunction:: set_base_dir
 ```
 
-<!-- TODO: Create examples -->
+See [Model I/O and external data workflows](../model_io.md) for saving,
+sharding, callbacks, and safetensors, and
+[Performance and large-model workflows](../performance.md) for memory guidance.

--- a/docs/api/ir_journaling.md
+++ b/docs/api/ir_journaling.md
@@ -10,6 +10,9 @@ The `onnx_ir.journaling` module provides a journaling system for tracking and de
 This module is in alpha. The APIs can change.
 :::
 
+See [Debugging transformations](../debugging.md) for guidance on choosing a
+journal scope and combining journaling with structural inspection and validation.
+
 ## Quick Start
 
 Use the `Journal` class as a context manager to record operations:

--- a/docs/api/ir_passes.md
+++ b/docs/api/ir_passes.md
@@ -1,65 +1,18 @@
 # onnx_ir.passes
 
+The pass API defines transformation contracts, results, composition, lifecycle
+errors, and functionalization utilities. Reusable implementations are documented
+in {py:mod}`onnx_ir.passes.common`.
+
+See [Writing transformation passes](../writing_passes.md) for implementation,
+composition, metadata invalidation, and testing guidance. See
+[Model I/O](../model_io.md) for targeted normalization and validation tools.
+
 ```{eval-rst}
 .. automodule::onnx_ir.passes
 ```
 
-## Use built-in passes
-
-Common, reusable passes are implemented in {py:mod}`onnx_ir.passes.common`. You can use {py:class}`onnx_ir.passes.Sequential <onnx_ir.passes.Sequential>` to chain passes or use {py:class}`onnx_ir.passes.PassManager <onnx_ir.passes.PassManager>` which supports early stopping if no changes are made.
-
-### Example
-
-```py
-import onnx_ir as ir
-import onnx_ir.passes.common as common_passes
-
-model = ir.load("model.onnx")
-
-# You can chain passes with ir.passes.Sequential
-passes = ir.passes.Sequential(
-    common_passes.DeduplicateHashedInitializersPass(size_limit=1024 * 1024),
-    common_passes.CommonSubexpressionEliminationPass(),
-)
-result = passes(model)
-
-# Or you can run passes individually. Passing in result or result.model has the same effect
-result = common_passes.ClearMetadataAndDocStringPass()(result)
-
-print("The model was modified:", result.modified)
-ir.save(result.model, "model.onnx")
-```
-
-For more advanced use cases, you can use {py:class}`onnx_ir.passes.PassManager <onnx_ir.passes.PassManager>` to orchestrate passes with automatic iteration until convergence:
-
-```py
-model = ir.load("model.onnx")
-
-passes = ir.passes.PassManager(
-    [
-        # Pass managers can be nested
-        ir.passes.PassManager(
-            [
-                common_passes.DeduplicateHashedInitializersPass(size_limit=1024 * 1024),
-                common_passes.CommonSubexpressionEliminationPass(),
-            ],
-            steps=2,
-            early_stop=True,
-        ),
-        common_passes.ClearMetadataAndDocStringPass(),
-    ],
-    steps=2,
-    early_stop=False,
-)
-
-result = passes(model)
-```
-
 ## Pass infrastructure
-
-Inherit from {py:class}`onnx_ir.passes.InPlacePass <onnx_ir.passes.InPlacePass>` or {py:class}`onnx_ir.passes.FunctionalPass <onnx_ir.passes.FunctionalPass>` to define a pass. You will need to implement the `call` method which returns a {py:class}`onnx_ir.passes.PassResult <onnx_ir.passes.PassResult>`.
-
-Alternatively, inherit from the base class {py:class}`onnx_ir.passes.PassBase <onnx_ir.passes.PassBase>` and override the two properties `changes_input` and `in_place` to set properties of the pass.
 
 ```{eval-rst}
 .. autosummary::

--- a/docs/api/ir_passes_common.md
+++ b/docs/api/ir_passes_common.md
@@ -2,8 +2,12 @@
 
 Built-in passes provided by the ONNX IR
 
+See [Writing transformation passes](../writing_passes.md) for composition and
+custom pass authoring, [Subgraphs and functions](../subgraphs_and_functions.md)
+for inlining, and [Model I/O](../model_io.md) for validation workflows.
+
 ```{eval-rst}
-.. automodule:: onnx_ir.passes.common
+.. automodule::onnx_ir.passes.common
     :show-inheritance:
     :members:
     :undoc-members:

--- a/docs/api/ir_schemas.md
+++ b/docs/api/ir_schemas.md
@@ -1,5 +1,8 @@
 # onnx_ir.schemas
 
+See [Writing transformation passes](../writing_passes.md) for using schema and
+opset requirements in transformation pipelines.
+
 ```{eval-rst}
 .. automodule:: onnx_ir.schemas
 .. currentmodule:: onnx_ir.schemas

--- a/docs/api/ir_tape.md
+++ b/docs/api/ir_tape.md
@@ -7,6 +7,10 @@
 
 The `onnx_ir.tape` module provides utilities for recording nodes and initializers to construct computational graphs or functions.
 
+See [Constructing models](../model_construction.md) for direct and tape-based
+construction examples, and [Debugging transformations](../debugging.md) for using
+a tape to reduce construction failures.
+
 ## The `Tape` class
 
 The `Tape` class is a recorder that collects nodes and initializers created during the construction of a graph or function. It supports creating nodes with single or multiple outputs and registering initializers.

--- a/docs/api/ir_tensor_adapters.md
+++ b/docs/api/ir_tensor_adapters.md
@@ -1,5 +1,9 @@
 # onnx_ir.tensor_adapters
 
+See [Tensor Representation in the IR](../tensors.md) for tensor backends and
+[Performance and large-model workflows](../performance.md) for avoiding
+unnecessary materialization.
+
 ```{eval-rst}
 .. automodule:: onnx_ir.tensor_adapters
 ```

--- a/docs/api/ir_traversal.md
+++ b/docs/api/ir_traversal.md
@@ -1,7 +1,11 @@
 # onnx_ir.traversal
 
+See [Subgraphs and functions](../subgraphs_and_functions.md) for scope-aware
+traversal and [Writing transformation passes](../writing_passes.md) for pass
+patterns.
+
 ```{eval-rst}
-.. automodule:: onnx_ir.traversal
+.. automodule::onnx_ir.traversal
 .. currentmodule:: onnx_ir.traversal
 ```
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,133 @@
+# Debugging transformations
+
+ONNX IR provides readable object displays, ONNX text conversion, mutation
+journaling, and construction tapes for inspecting model transformations.
+
+## Print or display IR objects
+
+`Model`, `Graph`, `Node`, `Value`, and tensor objects have compact string
+representations:
+
+```python
+print(model.graph)
+print(node)
+```
+
+Call `display()` for syntax-highlighted terminal output when `rich` is installed:
+
+```console
+pip install rich
+```
+
+```python
+model.display()
+model.graph.display(page=True)
+```
+
+`page=True` opens a terminal pager, which is useful for large graphs.
+
+## Use ONNX text format
+
+Convert a model to the standard ONNX textual syntax when comparing structure with
+other ONNX tools:
+
+```python
+text = ir.to_onnx_text(model)
+print(text)
+
+round_tripped = ir.from_onnx_text(text)
+```
+
+Pass `exclude_initializers=True` to `to_onnx_text` when large constant values
+would obscure the graph structure. Text conversion serializes through ONNX and is
+best used for diagnostics or interchange rather than inside performance-sensitive
+transformation loops.
+
+## Record mutations with a journal
+
+The alpha {py:mod}`onnx_ir.journaling` API records supported IR operations,
+including stack traces and object references:
+
+```python
+from onnx_ir.journaling import Journal
+
+with Journal() as journal:
+    transform(model)
+
+journal.display()
+```
+
+Inspect `journal.entries` to filter by operation or class, call
+`entry.display()` for full details, or attach a hook for real-time logging:
+
+```python
+journal = Journal()
+journal.add_hook(lambda entry: print(entry.operation, entry.class_name))
+```
+
+Keep the journal scope focused around the suspicious transformation. Recording a
+large pipeline creates substantial diagnostic output and stack-trace data.
+
+## Inspect graph relationships
+
+Use object relationships rather than names when diagnosing connectivity:
+
+```python
+print(value.producer())
+print(list(value.uses()))
+print(list(value.consumers()))
+print(node.predecessors())
+print(node.successors())
+print(node.graph)
+```
+
+For nested graphs, use `RecursiveGraphIterator` and
+`analysis.analyze_implicit_usage` to reveal control-flow bodies and outer-scope
+captures.
+
+## Isolate a failing region
+
+{py:func}`onnx_ir.convenience.extract` can clone a bounded region into a smaller
+graph for inspection or reproduction:
+
+```python
+region = ir.convenience.extract(
+    model.graph,
+    inputs=["x", "weight"],
+    outputs=["y"],
+)
+region.display()
+```
+
+Extraction reports undeclared frontier dependencies instead of silently creating
+an incomplete graph.
+
+## Validate between pipeline stages
+
+When a long pass pipeline fails, insert focused checks to locate the first invalid
+stage:
+
+```python
+import onnx_ir.passes.common as common_passes
+
+checker = common_passes.CheckerPass()
+
+for pass_ in passes:
+    result = pass_(model)
+    model = result.model
+    checker(model)
+```
+
+This per-stage checking is a diagnostic technique, not a recommended production
+pipeline: it serializes and checks the whole model after each pass.
+
+Topological sorting, name fixing, shape inference, and ONNX checking test different
+properties. Apply the checks relevant to the invariant each stage promises.
+
+## Use Tape to reproduce construction bugs
+
+{py:class}`onnx_ir.tape.Tape` records nodes and initializers while constructing a
+graph. It is useful for reducing a failing model to a short sequence of operations
+that can be copied into a regression test.
+
+See [Constructing models](model_construction.md) for a complete example.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,18 @@ operations (such as certain conversions or materializations) may copy data.
 ## Can I mutate a graph while iterating nodes?
 
 Yes. ONNX IR is designed for robust mutation workflows and supports safe
-iteration patterns during graph edits.
+iteration patterns during graph edits. Nodes inserted after the current node are
+visited; nodes inserted before it are not. If the current node is removed or
+moved, iteration continues from the node that followed its original location.
+
+See [Graph transformation patterns](graph_transformations.md).
+
+## How do I infer symbolic shapes?
+
+Use the built-in `ShapeInferencePass` for ONNX shape inference. For richer SymPy
+expressions, shape-data propagation, and custom operator inference, use the
+optional [`onnx-shape-inference`](https://pypi.org/project/onnx-shape-inference/)
+package.
 
 ## Where is the API reference?
 

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "source": [
     "# Getting started with ONNX IR 🌱\n",
-    "The ONNX IR is available as `onnx_ir`.\n",
-    "To create an IR object from ONNX file, load it as `ModelProto` and call\n",
-    "`ir.from_proto()`:"
+    "The ONNX IR is available as `onnx_ir`. Use `ir.load(\"model.onnx\")` to load\n",
+    "a model from disk. This notebook starts from ONNX text so it is self-contained,\n",
+    "then demonstrates inspection, transformation, validation, and saving."
    ]
   },
   {
@@ -26,7 +26,7 @@
     "   producer_version: \"2.0.0\"\n",
     ">\n",
     "torch_jit (float[5,5,5] input_0) => (float[5,5] val_19, float[5,5] val_6) {\n",
-    "   [node_1] val_1 = Constant <value_int: ints = [1]> ()\n",
+    "   [node_1] val_1 = Constant <value_int: int = 1> ()\n",
     "   [node_2] val_2 = Shape <start: int = 0> (val_1)\n",
     "   [node_3] val_3 = Size (val_2)\n",
     "   [node_4] val_4 = Constant <value: tensor = int64 {0}> ()\n",
@@ -280,17 +280,97 @@
    "id": "cf19aa88-2063-4fee-9dd8-5fdca1dab398",
    "metadata": {},
    "source": [
-    "Convert from the IR object back to ModelProto"
+    "## Transform the graph\n",
+    "\n",
+    "Add an `Identity` after the second graph output and make its result the new output."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "3b146b60-602a-4cb1-a5f8-d8d22c2a6a72",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_proto_back = ir.to_proto(model)"
+    "old_output = model.graph.outputs[-1]\n",
+    "producer = old_output.producer()\n",
+    "assert producer is not None\n",
+    "\n",
+    "identity = ir.node(\"Identity\", inputs=[old_output], name=\"output_identity\")\n",
+    "identity.outputs[0].type = old_output.type\n",
+    "identity.outputs[0].shape = old_output.shape\n",
+    "model.graph.insert_after(producer, identity)\n",
+    "model.graph.outputs[-1] = identity.outputs[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17d7e6ad-baf9-4bf9-a3c2-279f718ce847",
+   "metadata": {},
+   "source": [
+    "The insertion preserves names, ownership, use-def relationships, and topological\n",
+    "order, so no repair passes are needed. At this tutorial's validation boundary,\n",
+    "run the ONNX checker explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04a20a22-02d0-42ca-86c4-b02340aa5d1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import onnx_ir.passes.common as common_passes\n",
+    "\n",
+    "common_passes.CheckerPass(full_check=True)(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b0be6bf-3511-46d7-b903-cda2ab246c64",
+   "metadata": {},
+   "source": [
+    "## Save and reload\n",
+    "\n",
+    "Use `ir.save` and `ir.load` at file boundaries. A temporary directory keeps this\n",
+    "notebook from leaving generated files behind."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49a8f598-b119-4694-9e95-94b8a94ad8ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "\n",
+    "with tempfile.TemporaryDirectory() as temp_dir:\n",
+    "    model_path = os.path.join(temp_dir, \"model.onnx\")\n",
+    "    ir.save(model, model_path)\n",
+    "    reloaded_model = ir.load(model_path)\n",
+    "\n",
+    "assert reloaded_model.graph.outputs[-1].producer().op_type == \"Identity\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5be911bc-7e8c-4ba0-a525-52307efc902b",
+   "metadata": {},
+   "source": [
+    "Convert to or from `ModelProto` explicitly when integrating with protobuf-based APIs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46889035-5d91-494d-a17c-61a6744c91f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_proto_back = ir.to_proto(model)\n",
+    "model_round_trip = ir.from_proto(model_proto_back)"
    ]
   },
   {
@@ -300,7 +380,10 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "Read the introductions for a more detailed introduction of the IR."
+    "- Read [Introduction to the IR](ir.md) for design principles and the object model.\n",
+    "- Read [Constructing models](model_construction.md) to build models from scratch.\n",
+    "- Read [Graph transformation patterns](graph_transformations.md) for common rewrites.\n",
+    "- Read [Writing transformation passes](writing_passes.md) for reusable pipelines."
    ]
   }
  ],

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Getting started with ONNX IR 🌱\n",
-    "The ONNX IR ships with the ONNX Script package and is available as `onnx_ir`.\n",
+    "The ONNX IR is available as `onnx_ir`.\n",
     "To create an IR object from ONNX file, load it as `ModelProto` and call\n",
     "`ir.from_proto()`:"
    ]
@@ -300,8 +300,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "Read the introductions for a more detailed introduction of the IR\n",
-    "(Documentation in progress 🚧)"
+    "Read the introductions for a more detailed introduction of the IR."
    ]
   }
  ],

--- a/docs/graph_transformations.md
+++ b/docs/graph_transformations.md
@@ -4,6 +4,26 @@ This page documents practical graph-editing patterns exposed by `onnx_ir` source
 APIs, especially those in `onnx_ir.convenience`, `onnx_ir.traversal`, and
 `onnx_ir.analysis`.
 
+## Choose the scopes to transform
+
+Direct iteration processes only one graph. Use recursive traversal for nested
+graph attributes, and process model-local functions separately:
+
+```python
+import onnx_ir as ir
+
+
+def iter_model_nodes(model: ir.Model):
+    yield from ir.traversal.RecursiveGraphIterator(model.graph)
+    for function in model.functions.values():
+        yield from ir.traversal.RecursiveGraphIterator(function)
+```
+
+Not every rewrite should apply to every scope. Decide explicitly whether the
+transformation supports control-flow subgraphs, implicit captures, and functions.
+When replacing values, use `replace_graph_outputs=True` if graph outputs should
+also be redirected.
+
 ## Mutate a graph during iteration
 
 It is safe to insert, remove, or move nodes while iterating over a graph. The
@@ -139,3 +159,23 @@ non-initializer value enters the region but is not listed in `inputs`, extractio
 raises `ValueError` rather than creating a graph with an undeclared dependency.
 At least one output is required, and supplied `Value` objects must belong to the
 source graph unless the source is a {py:class}`onnx_ir.GraphView`.
+
+## Preserve invariants and use targeted repair
+
+A well-formed transformation should maintain the invariants it does not intend to
+change, including use-def links, unique required names, and topological order.
+Avoid routinely running cleanup passes after every rewrite: each pass adds another
+model traversal and may be expensive for large models.
+
+Use a normalization or analysis pass only when the transformation's contract
+requires it:
+
+- Run `NameFixPass` if the rewrite can introduce missing or duplicate names.
+- Run `TopologicalSortPass` if nodes may no longer be in topological order.
+- Run shape inference only when the rewrite invalidates shape/type information and
+  a later stage requires it.
+- Run `CheckerPass` at explicit validation boundaries or while diagnosing a
+  transformation, rather than after every pass.
+
+Document these effects in reusable passes so callers know which invariants remain
+valid and which follow-up work, if any, is necessary.

--- a/docs/graph_transformations.md
+++ b/docs/graph_transformations.md
@@ -112,7 +112,8 @@ for subgraph, captured in implicit.items():
 ## Extract a bounded subgraph
 
 Use `convenience.extract` to carve out a model region with explicit frontier
-inputs/outputs.
+inputs and outputs. Inputs and outputs may be specified as `Value` objects or by
+name.
 
 ```python
 subgraph = ir.convenience.extract(
@@ -121,3 +122,20 @@ subgraph = ir.convenience.extract(
     outputs=["y"],
 )
 ```
+
+Extraction walks backward from the requested outputs until it reaches the
+requested inputs. It:
+
+- includes the nodes required to compute the outputs, preserving their original
+  order;
+- includes required initializers automatically;
+- follows outer-scope values captured by nested graph attributes;
+- preserves the source name, documentation, opset imports, and serialized
+  metadata;
+- returns an independent cloned {py:class}`onnx_ir.Graph`.
+
+The requested inputs must fully bound the extracted region. If a required
+non-initializer value enters the region but is not listed in `inputs`, extraction
+raises `ValueError` rather than creating a graph with an undeclared dependency.
+At least one output is required, and supplied `Value` objects must belong to the
+source graph unless the source is a {py:class}`onnx_ir.GraphView`.

--- a/docs/graph_transformations.md
+++ b/docs/graph_transformations.md
@@ -4,6 +4,35 @@ This page documents practical graph-editing patterns exposed by `onnx_ir` source
 APIs, especially those in `onnx_ir.convenience`, `onnx_ir.traversal`, and
 `onnx_ir.analysis`.
 
+## Mutate a graph during iteration
+
+It is safe to insert, remove, or move nodes while iterating over a graph. The
+iterator preserves its position using the node's original location:
+
+- Nodes inserted after the current node are visited during the same iteration.
+- Nodes inserted before the current node are not visited during that iteration.
+- If the current node is removed or moved, iteration continues from the node that
+  followed it at its original location.
+
+For example, this loop can replace nodes without first copying the graph's node
+list:
+
+```python
+import onnx_ir as ir
+
+for node in graph:
+    if node.op_type != "Dropout":
+        continue
+
+    replacement = ir.node("Identity", inputs=node.inputs)
+    graph.insert_after(node, [replacement])
+    node.outputs[0].replace_all_uses_with(
+        replacement.outputs[0],
+        replace_graph_outputs=True,
+    )
+    graph.remove([node], safe=True)
+```
+
 ## Replace all downstream uses of a value
 
 Use `ir.convenience.replace_all_uses_with` when replacing one value-producing

--- a/docs/graph_transformations.md
+++ b/docs/graph_transformations.md
@@ -160,6 +160,7 @@ raises `ValueError` rather than creating a graph with an undeclared dependency.
 At least one output is required, and supplied `Value` objects must belong to the
 source graph unless the source is a {py:class}`onnx_ir.GraphView`.
 
+(invariant-preservation)=
 ## Preserve invariants and use targeted repair
 
 A well-formed transformation should maintain the invariants it does not intend to

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ tensors
 multi_device
 model_io
 graph_transformations
+writing_passes
 onnx_helper_migration
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,11 +29,15 @@ installation
 :caption: User Guides
 
 ir
+model_construction
 tensors
 multi_device
 model_io
 graph_transformations
+subgraphs_and_functions
 writing_passes
+performance
+debugging
 onnx_helper_migration
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,18 +26,9 @@ installation
 
 ```{toctree}
 :maxdepth: 2
-:caption: Reliability and Operations
-
-stability
-faq
-security
-release_checklist
-```
-
-```{toctree}
-:maxdepth: 2
 :caption: User Guides
 
+ir
 tensors
 multi_device
 model_io
@@ -50,4 +41,14 @@ onnx_helper_migration
 :caption: API Reference
 
 api/index
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Reliability and Operations
+
+stability
+faq
+security
+release_checklist
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,6 +25,25 @@ pip install -e .
 python -c "import onnx_ir as ir; print(ir.__version__)"
 ```
 
+## Optional integrations
+
+Install optional packages only for the workflows that need them:
+
+| Package | Purpose |
+|---|---|
+| `onnx-shape-inference` | IR-native symbolic shape inference with SymPy expressions and shape-data propagation |
+| `safetensors>=0.7.0` | Save model weights with `ir.save_safetensors` |
+| `rich` | Syntax-highlighted `display()` output and paging |
+| `torch` | PyTorch tensor adapter and dtype conversion utilities |
+
+```bash
+pip install onnx-shape-inference "safetensors>=0.7.0" rich
+```
+
+ONNX IR does not require these packages for its core model, graph, and tensor
+APIs. See [Model I/O](model_io.md), [Tensor Representation](tensors.md), and
+[Debugging transformations](debugging.md) for integration-specific usage.
+
 ## Recommended setup for production workflows
 
 1. Use a dedicated virtual environment per project.

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -74,6 +74,40 @@ Use a {py:class}`onnx_ir.GraphView` when an analysis needs a read-only view over
 subset of nodes. A view does not copy or take ownership of its nodes, and changes
 to the underlying connections remain visible through the view.
 
+#### Ownership and graph invariants
+
+The IR maintains ownership and use-def relationships as graph objects are edited:
+
+- A node belongs to at most one graph. Remove it from its current graph before
+  inserting it into another one.
+- A node owns its output values. Each output therefore has exactly one producer.
+- Graph and function inputs have no producer.
+- An initializer must be named, have a constant value, and have no producer.
+- Graph outputs reference existing values; they are not a separate copy of those
+  values.
+
+Use `graph.remove(nodes, safe=True)` for removal. Safe removal rejects nodes whose
+outputs are still used or contribute to graph outputs, then detaches the removed
+nodes from their inputs so use-def information remains consistent.
+
+Node order is deterministic but is not automatically topological. Call
+`graph.sort()` after a rewrite when the transformation does not naturally preserve
+topological order. The stable sort also processes nested subgraphs and raises
+`ValueError` if it finds a cycle.
+
+#### Views and clones
+
+A {py:class}`onnx_ir.GraphView` provides a fixed, read-only topology over existing
+nodes and values. It is useful for analysis or serialization of a region without
+copying that region.
+
+Use `graph.clone()` or `model.clone()` when the result must be independently
+mutable. Cloning creates new graph, node, and value objects while sharing tensors
+used by initializers and constants. Pass `deep_copy=True` to also deep-copy
+analysis metadata stores. When cloning a nested graph independently, set
+`allow_outer_scope_values=True` if its captured outer-scope values should remain
+shared.
+
 ### Node
 
 A {py:class}`onnx_ir.Node` represents an operator invocation. It stores the
@@ -133,6 +167,58 @@ Constant data uses the {py:class}`onnx_ir.TensorProtocol` interface. Operator
 attributes use {py:class}`onnx_ir.Attr` and can contain scalar values, sequences,
 tensors, graphs, types, and ONNX function attribute references.
 
+### Subgraphs and functions
+
+Control-flow operators store subgraphs in node attributes. A subgraph can
+implicitly capture values from an enclosing graph in addition to declaring its own
+inputs, initializers, and outputs. Each graph also carries its own opset imports.
+Use {py:class}`onnx_ir.traversal.RecursiveGraphIterator` or `graph.all_nodes()` to
+visit nodes in nested subgraphs.
+
+A {py:class}`onnx_ir.Function` defines a reusable, model-local operator identified
+by `(domain, name, overload)`. Like a graph, it owns inputs, outputs, nodes,
+attributes, and opset imports. Functions are stored separately from the main graph,
+so analyses and transformations that apply to the whole model should process both:
+
+```python
+for node in model.graph.all_nodes():
+    analyze(node)
+
+for function in model.functions.values():
+    for node in function.all_nodes():
+        analyze(node)
+```
+
+### Names and identity
+
+Objects are connected by identity, not by their names. Names are primarily for
+serialization, diagnostics, and lookup.
+
+When an unnamed node is added to a graph, the graph assigns names such as
+`node_Relu_0`; unnamed outputs receive names such as `val_0`. Explicit names are
+preserved, even if they collide, so callers remain responsible for the uniqueness
+of names they provide. Automatically generated names are reserved for the lifetime
+of the graph and are not reused after removal.
+
+Run {py:class}`onnx_ir.passes.common.NameFixPass` to normalize an entire model
+before serialization. It assigns missing names, resolves duplicate node and value
+names, handles nested graph scopes, updates initializer mappings, and processes
+model-local functions:
+
+```python
+import onnx_ir.passes.common as common_passes
+
+result = common_passes.NameFixPass()(model)
+model = result.model
+```
+
+Pass a custom `NameGenerator` to `NameFixPass` when generated names should follow
+a project-specific convention.
+
+Renaming an initializer also requires updating the graph's initializer mapping.
+Use {py:func}`onnx_ir.convenience.rename_values` for collision-aware bulk renaming
+that handles initializer bookkeeping when only selected values should change.
+
 ## Major features
 
 ### Full ONNX coverage
@@ -187,5 +273,6 @@ reduce boilerplate when constructing models.
 - [Getting started with ONNX IR](getting_started.ipynb) for loading and exploring
   a model.
 - [Graph transformation patterns](graph_transformations.md) for common rewrites.
+- [Writing transformation passes](writing_passes.md) for reusable transformations.
 - [Model I/O and external data workflows](model_io.md) for serialization.
 - [API Reference](api/index.md) for the complete public API.

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -1,0 +1,191 @@
+# Introduction to the IR
+
+ONNX IR is an in-memory representation of ONNX models for graph construction,
+analysis, and transformation. It represents the full ONNX specification while
+providing Python-native objects and mutation APIs that are more convenient than
+editing protobuf messages directly.
+
+This page explains the IR's design principles, object model, and major features.
+For a hands-on walkthrough, see [Getting started with ONNX IR](getting_started.ipynb).
+
+## Design principles
+
+### Preserve the ONNX model
+
+The IR maps closely to ONNX concepts so models can be loaded, inspected, changed,
+and serialized without losing information. It supports all valid ONNX models and
+also permits some temporarily invalid states, which is useful when a transformation
+needs several steps to repair or rewrite a graph.
+
+### Make graph relationships explicit
+
+Connections are represented by object references instead of repeated string
+lookups. A {py:class}`onnx_ir.Value` knows its producer and consumers, a
+{py:class}`onnx_ir.Node` owns its output values, and a
+{py:class}`onnx_ir.Graph` owns an ordered collection of nodes. These relationships
+make common analysis and rewriting operations direct and efficient.
+
+### Support safe, local mutation
+
+Graph edits update the relevant ownership and use-def relationships. The graph's
+node container supports insertion and removal during iteration, so transformation
+passes can edit a graph without first copying its node list.
+
+Nodes are stored in a deterministic order, but the IR does not automatically
+topologically sort them. Transformations are responsible for preserving or
+restoring topological order when required.
+
+### Separate representation from serialization
+
+ONNX protobuf is an interchange format; it does not need to be the working data
+structure. After deserialization, the IR can be used without manipulating protobuf
+objects. Serialization and deserialization are explicit boundaries through
+functions such as {py:func}`onnx_ir.load`, {py:func}`onnx_ir.save`,
+{py:func}`onnx_ir.from_proto`, and {py:func}`onnx_ir.to_proto`.
+
+### Avoid unnecessary tensor copies
+
+Tensor data is accessed through {py:class}`onnx_ir.TensorProtocol`, which allows
+the IR to work with different storage backends through one interface. Implementations
+include in-memory arrays, protobuf-backed tensors, memory-mapped external tensors,
+lazy tensors, and packed low-bit tensors.
+
+## Object model
+
+![Relationships among the main ONNX IR entities](resource/onnx-ir-entities.svg)
+
+### Model
+
+A {py:class}`onnx_ir.Model` is the top-level container. It holds:
+
+- the main graph;
+- the ONNX IR version;
+- producer, domain, version, and documentation information;
+- model-local functions;
+- serializable metadata and multi-device configuration.
+
+### Graph
+
+A {py:class}`onnx_ir.Graph` represents a computation and behaves as a sequence of
+nodes. It also owns graph inputs, graph outputs, initializers, and opset imports.
+Subgraphs stored in node attributes use the same graph representation.
+
+Use a {py:class}`onnx_ir.GraphView` when an analysis needs a read-only view over a
+subset of nodes. A view does not copy or take ownership of its nodes, and changes
+to the underlying connections remain visible through the view.
+
+### Node
+
+A {py:class}`onnx_ir.Node` represents an operator invocation. It stores the
+operator domain, type, overload, attributes, inputs, and output values. Node
+inputs may be replaced, while output values are fixed when the node is created.
+To replace outputs, create a new node and redirect uses of the old values.
+
+Nodes also provide direct graph-neighbor traversal. `predecessors()` returns the
+nodes that produce the node's inputs, while `successors()` returns the nodes that
+consume its outputs. Both results are deduplicated and have deterministic order:
+
+```python
+predecessors = node.predecessors()
+successors = node.successors()
+```
+
+### Value
+
+A {py:class}`onnx_ir.Value` represents data flowing through the graph. A value can
+be a graph input, initializer, node output, or graph output, and may carry type,
+shape, constant data, documentation, and metadata.
+
+Every value has at most one producer and can have many uses. The producer/use
+links support both directions of graph traversal:
+
+```python
+producer = value.producer()
+consumers = list(value.consumers())
+uses = list(value.uses())  # Each use includes the node and input index.
+```
+
+### Types, shapes, tensors, and attributes
+
+{py:class}`onnx_ir.Value` objects carry ONNX types such as tensor, sparse tensor,
+sequence, and optional types. Tensor shapes are represented by
+{py:class}`onnx_ir.Shape` and may contain static integer dimensions or shared
+{py:class}`onnx_ir.SymbolicDim` objects. A symbolic dimension can store a SymPy
+expression, enabling shape arithmetic that can later be evaluated with concrete
+symbol bindings:
+
+```python
+import sympy
+
+import onnx_ir as ir
+
+batch = sympy.Symbol("batch", integer=True, positive=True)
+shape = ir.Shape(
+    [
+        ir.SymbolicDim(batch),
+        ir.SymbolicDim(batch * 2 + 1),
+    ]
+)
+concrete_shape = shape.evaluate({"batch": 4})  # Shape([4, 9])
+```
+
+Constant data uses the {py:class}`onnx_ir.TensorProtocol` interface. Operator
+attributes use {py:class}`onnx_ir.Attr` and can contain scalar values, sequences,
+tensors, graphs, types, and ONNX function attribute references.
+
+## Major features
+
+### Full ONNX coverage
+
+The IR represents models, graphs, functions, nested subgraphs, opset imports,
+attributes, type and shape information, metadata properties, external tensor data,
+and newer model features such as multi-device configuration.
+
+### Use-def tracking
+
+Producer and consumer information is maintained by the IR. Rewriters can inspect
+uses, replace node inputs, replace all uses of a value, and safely check whether a
+node can be removed.
+
+### Robust graph editing
+
+Graphs provide methods to append, insert, remove, and reorder nodes. Iterators
+remain usable while nodes are inserted or removed, enabling single-pass
+transformations. Higher-level helpers for common rewrites are available in
+{py:mod}`onnx_ir.convenience`.
+
+### Flexible tensor storage
+
+Tensor implementations can wrap NumPy-compatible arrays without an eager protobuf
+conversion. External tensors use memory mapping to avoid loading entire weight
+files into memory, and custom tensor implementations can implement
+{py:class}`onnx_ir.TensorProtocol` to integrate other storage systems.
+
+See [Tensor Representation in the IR](tensors.md) for details.
+
+### Serializable and analysis-only metadata
+
+IR objects expose two metadata stores:
+
+- `metadata_props` contains string key-value pairs that are serialized to ONNX.
+- `meta` contains arbitrary Python objects for analyses and transformations and
+  supports invalidation when cached information must be recomputed.
+
+Keeping these stores separate lets passes attach rich intermediate state without
+accidentally changing the serialized model.
+
+### Pythonic APIs
+
+Core entities use standard Python collection interfaces: graphs and functions are
+node sequences, attributes and initializers are mapping-like containers, and graph
+inputs and outputs are mutable sequences. Convenience constructors such as
+{py:func}`onnx_ir.node`, {py:func}`onnx_ir.val`, and {py:func}`onnx_ir.tensor`
+reduce boilerplate when constructing models.
+
+## Where to go next
+
+- [Getting started with ONNX IR](getting_started.ipynb) for loading and exploring
+  a model.
+- [Graph transformation patterns](graph_transformations.md) for common rewrites.
+- [Model I/O and external data workflows](model_io.md) for serialization.
+- [API Reference](api/index.md) for the complete public API.

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -200,10 +200,9 @@ preserved, even if they collide, so callers remain responsible for the uniquenes
 of names they provide. Automatically generated names are reserved for the lifetime
 of the graph and are not reused after removal.
 
-Run {py:class}`onnx_ir.passes.common.NameFixPass` to normalize an entire model
-before serialization. It assigns missing names, resolves duplicate node and value
-names, handles nested graph scopes, updates initializer mappings, and processes
-model-local functions:
+Run {py:class}`onnx_ir.passes.common.NameFixPass` when an imported or transformed
+model may contain missing or duplicate names. It handles nested graph scopes,
+updates initializer mappings, and processes model-local functions:
 
 ```python
 import onnx_ir.passes.common as common_passes

--- a/docs/model_construction.md
+++ b/docs/model_construction.md
@@ -1,0 +1,142 @@
+# Constructing models
+
+ONNX IR provides Python-native constructors for values, tensors, nodes, graphs,
+and models. Construct objects directly when the graph structure is explicit, or
+use {py:class}`onnx_ir.tape.Tape` when building a longer sequence of operations.
+
+## Build a model directly
+
+Create graph inputs and outputs with {py:func}`onnx_ir.val`. Static dimensions
+are integers; strings create symbolic dimensions.
+
+```python
+import onnx_ir as ir
+
+x = ir.val("x", dtype=ir.DataType.FLOAT, shape=["batch", 4])
+y = ir.val("y", dtype=ir.DataType.FLOAT, shape=["batch", 4])
+```
+
+Initializers are values with constant tensor data:
+
+```python
+bias = ir.val(
+    "bias",
+    const_value=ir.tensor(
+        [1.0, 2.0, 3.0, 4.0],
+        dtype=ir.DataType.FLOAT,
+    ),
+)
+```
+
+Create nodes with {py:func}`onnx_ir.node`. Plain Python attribute values are
+converted to ONNX attributes automatically.
+
+```python
+add = ir.node("Add", inputs=[x, bias], name="add_bias")
+relu = ir.node("Relu", inputs=add.outputs, outputs=[y], name="relu")
+```
+
+Assemble the graph and model:
+
+```python
+graph = ir.Graph(
+    inputs=[x],
+    outputs=[y],
+    nodes=[add, relu],
+    initializers=[bias],
+    opset_imports={"": 21},
+    name="main_graph",
+)
+model = ir.Model(graph, ir_version=10)
+```
+
+Values and nodes are connected by object identity. The strings used as names are
+for serialization, diagnostics, and lookup; they do not create graph edges.
+
+## Add nodes incrementally
+
+Graph mutation methods establish ownership, assign missing names, and maintain
+use-def relationships:
+
+```python
+sigmoid = ir.node("Sigmoid", inputs=[graph.outputs[0]])
+graph.append(sigmoid)
+graph.outputs[0] = sigmoid.outputs[0]
+```
+
+A node can belong to only one graph. Remove it from its current graph before
+moving it to another graph.
+
+Use `graph.register_initializer(value)` to add an initializer after graph
+construction. The value must be named, have `const_value`, and have no producer.
+
+## Use Tape for sequential construction
+
+{py:class}`onnx_ir.tape.Tape` records nodes and initializers while returning
+values that can be passed directly to later operations:
+
+```python
+tape = ir.tape.Tape()
+
+weight = tape.initializer(
+    ir.tensor(
+        [[1.0, 0.0], [0.0, 1.0]],
+        dtype=ir.DataType.FLOAT,
+        name="weight",
+    )
+)
+x = ir.val("x", dtype=ir.DataType.FLOAT, shape=["batch", 2])
+
+matmul = tape.op("MatMul", [x, weight])
+output = tape.op("Relu", [matmul])
+
+graph = ir.Graph(
+    inputs=[x],
+    outputs=[output],
+    nodes=tape.nodes,
+    initializers=tape.initializers,
+    opset_imports={"": 21},
+    name="main_graph",
+)
+model = ir.Model(graph, ir_version=10)
+```
+
+Use `op_multi_out` for operators with multiple outputs. `tape.used_opsets`
+records the domain and explicit version requested by each operation, but callers
+still choose the graph's final opset imports.
+
+## Preserve public interfaces
+
+Graph input and output names are part of a model's external interface. Keep them
+explicit when constructing or rewriting models. Intermediate names may be omitted
+and assigned automatically when nodes enter a graph.
+
+Run {py:class}`onnx_ir.passes.common.NameFixPass` only when construction may have
+introduced missing or duplicate names:
+
+```python
+import onnx_ir.passes.common as common_passes
+
+model = common_passes.NameFixPass()(model).model
+```
+
+## Preserve construction invariants
+
+Construction APIs intentionally permit intermediate states that may not yet form
+a valid ONNX model. Build nodes in topological order, keep public names unique,
+and provide required type information directly when possible.
+
+Use targeted passes only for invariants the construction process did not preserve:
+
+- `NameFixPass` for missing or duplicate names.
+- `TopologicalSortPass` for out-of-order nodes.
+- Shape inference when consumers require types or shapes that were not supplied.
+
+At an explicit validation boundary, the checker can confirm the completed model:
+
+```python
+common_passes.CheckerPass(full_check=True)(model)
+```
+
+See [Model I/O and external data workflows](model_io.md) for shape inference and
+serialization options.

--- a/docs/model_construction.md
+++ b/docs/model_construction.md
@@ -59,9 +59,13 @@ Graph mutation methods establish ownership, assign missing names, and maintain
 use-def relationships:
 
 ```python
-sigmoid = ir.node("Sigmoid", inputs=[graph.outputs[0]])
+old_output = graph.outputs[0]
+old_output.name = "relu_output"
+new_output = ir.val("y", type=old_output.type, shape=old_output.shape)
+
+sigmoid = ir.node("Sigmoid", inputs=[old_output], outputs=[new_output])
 graph.append(sigmoid)
-graph.outputs[0] = sigmoid.outputs[0]
+graph.outputs[0] = new_output
 ```
 
 A node can belong to only one graph. Remove it from its current graph before
@@ -126,11 +130,9 @@ Construction APIs intentionally permit intermediate states that may not yet form
 a valid ONNX model. Build nodes in topological order, keep public names unique,
 and provide required type information directly when possible.
 
-Use targeted passes only for invariants the construction process did not preserve:
-
-- `NameFixPass` for missing or duplicate names.
-- `TopologicalSortPass` for out-of-order nodes.
-- Shape inference when consumers require types or shapes that were not supplied.
+Use targeted passes only for invariants the construction process did not preserve.
+See [Preserve invariants and use targeted repair](invariant-preservation)
+for the authoritative checklist.
 
 At an explicit validation boundary, the checker can confirm the completed model:
 

--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -21,6 +21,9 @@ names, topological order, and type/shape information when possible. Normalizatio
 and inference passes traverse the model, so do not add them to every save path by
 default.
 
+See [Preserve invariants and use targeted repair](invariant-preservation)
+for the authoritative decision checklist.
+
 Apply only the operations required by the preceding transformations:
 
 ```python

--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -13,6 +13,69 @@ model = ir.load("model.onnx")
 ir.save(model, "updated.onnx")
 ```
 
+## Normalize and validate before saving
+
+The IR permits temporarily incomplete or invalid states so multi-step
+transformations can be expressed naturally. Before publishing a transformed
+model, explicitly restore and check the invariants required by ONNX:
+
+```python
+import onnx_ir.passes.common as common_passes
+
+pipeline = ir.passes.Sequential(
+    common_passes.TopologicalSortPass(),
+    common_passes.ShapeInferencePass(),
+    common_passes.CheckerPass(full_check=True),
+)
+result = pipeline(model)
+ir.save(result.model, "updated.onnx")
+```
+
+These stages serve different purposes:
+
+- `TopologicalSortPass` stably sorts the main graph, nested subgraphs, and model
+  functions. A cycle raises `ValueError`.
+- `ShapeInferencePass` asks ONNX shape inference to update value types and shapes.
+  If inference fails, it logs a warning and leaves the model unchanged.
+- `CheckerPass` serializes through the ONNX boundary and runs
+  `onnx.checker.check_model`; it does not modify the model.
+- `ir.save` performs final serialization and external-data handling.
+
+### Use symbolic shape inference
+
+For richer symbolic inference, use the optional
+[`onnx-shape-inference`](https://pypi.org/project/onnx-shape-inference/)
+package. It operates directly on ONNX IR, represents dimension arithmetic with
+SymPy expressions, propagates shape-tensor data through patterns such as
+`Shape -> Slice -> Concat -> Reshape`, and supports custom operator inference
+functions.
+
+```console
+pip install onnx-shape-inference
+```
+
+Replace the built-in `ShapeInferencePass` in the workflow when symbolic
+relationships are important:
+
+```python
+from onnx_shape_inference import infer_symbolic_shapes
+
+model = common_passes.TopologicalSortPass()(model).model
+model = infer_symbolic_shapes(model)
+common_passes.CheckerPass(full_check=True)(model)
+ir.save(model, "updated.onnx")
+```
+
+The default `refine` merge policy preserves compatible existing information while
+adding inferred details. Use `policy="strict"` to report conflicts between
+declared and inferred shapes. Other policies and extension APIs are documented in
+the [onnx-shape-inference project](https://github.com/justinchuby/onnx-shape-inference).
+
+Shape and type information is not automatically recomputed after every graph edit.
+Run inference when downstream transformations or consumers depend on updated
+information, and use pass preconditions or postconditions for requirements that
+are specific to your pipeline.
+
 ## Save large initializers as ONNX external data
 
 ```python

--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -13,22 +13,29 @@ model = ir.load("model.onnx")
 ir.save(model, "updated.onnx")
 ```
 
-## Normalize and validate before saving
+## Use normalization and validation when needed
 
 The IR permits temporarily incomplete or invalid states so multi-step
-transformations can be expressed naturally. Before publishing a transformed
-model, explicitly restore and check the invariants required by ONNX:
+transformations can be expressed naturally. Prefer transformations that preserve
+names, topological order, and type/shape information when possible. Normalization
+and inference passes traverse the model, so do not add them to every save path by
+default.
+
+Apply only the operations required by the preceding transformations:
 
 ```python
 import onnx_ir.passes.common as common_passes
 
-pipeline = ir.passes.Sequential(
-    common_passes.TopologicalSortPass(),
-    common_passes.ShapeInferencePass(),
-    common_passes.CheckerPass(full_check=True),
-)
-result = pipeline(model)
-ir.save(result.model, "updated.onnx")
+# Only if a rewrite may have disturbed node order.
+model = common_passes.TopologicalSortPass()(model).model
+
+# Only if stale shapes/types are needed by a later stage.
+model = common_passes.ShapeInferencePass()(model).model
+
+# At an explicit validation boundary, if desired.
+common_passes.CheckerPass(full_check=True)(model)
+
+ir.save(model, "updated.onnx")
 ```
 
 These stages serve different purposes:
@@ -54,16 +61,13 @@ functions.
 pip install onnx-shape-inference
 ```
 
-Replace the built-in `ShapeInferencePass` in the workflow when symbolic
-relationships are important:
+Use it instead of the built-in `ShapeInferencePass` when a later stage needs
+richer symbolic relationships:
 
 ```python
 from onnx_shape_inference import infer_symbolic_shapes
 
-model = common_passes.TopologicalSortPass()(model).model
 model = infer_symbolic_shapes(model)
-common_passes.CheckerPass(full_check=True)(model)
-ir.save(model, "updated.onnx")
 ```
 
 The default `refine` merge policy preserves compatible existing information while

--- a/docs/onnx_helper_migration.md
+++ b/docs/onnx_helper_migration.md
@@ -3,6 +3,9 @@
 This page shows practical migrations from common `onnx.helper` model-building
 patterns to `onnx_ir` APIs.
 
+For a native IR-first walkthrough without the protobuf comparison, see
+[Constructing models](model_construction.md).
+
 ## Why migrate
 
 `onnx_ir` keeps ONNX concepts (Model/Graph/Node/Value), but gives you:
@@ -112,6 +115,7 @@ graph = ir.Graph(
     nodes=[matmul],
     initializers=[weight],
     opset_imports={"": 20},
+    name="g",
 )
 ```
 
@@ -200,3 +204,5 @@ ir.save(submodel, "subgraph.onnx")
 2. Keep names explicit while migrating to preserve external interfaces.
 3. Prefer value-based rewrites (`replace_all_uses_with`) over positional list surgery.
 4. Use `ir.save`/`ir.load` at the boundaries and keep transformation logic in IR.
+5. Preserve names, topological order, and type/shape information during rewrites.
+   Run the corresponding repair or validation pass only when needed.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,90 @@
+# Performance and large-model workflows
+
+ONNX IR is designed to manipulate large models without eagerly materializing all
+tensor data or repeatedly converting between Python objects and protobuf.
+
+## Keep models in IR form
+
+Load once, perform a sequence of analyses and transformations in memory, and
+serialize at the boundary:
+
+```python
+import onnx_ir as ir
+
+model = ir.load("model.onnx")
+
+for pass_ in passes:
+    model = pass_(model).model
+
+ir.save(model, "optimized.onnx")
+```
+
+Avoid converting to `ModelProto` between passes. Serialization walks the model
+and may materialize or copy data depending on the tensor backend.
+
+## Avoid materializing large tensors
+
+{py:class}`onnx_ir.ExternalTensor` uses memory mapping for ONNX external data.
+Inspect `shape`, `dtype`, `size`, and `nbytes` before calling `numpy()` or
+`tobytes()`, because those operations access the tensor data.
+
+Prefer {py:class}`onnx_ir.TensorProtocol` in APIs so callers can provide in-memory,
+external, lazy, packed, or framework-backed tensors without an eager conversion.
+
+See [Tensor Representation in the IR](tensors.md) and
+[Model I/O and external data workflows](model_io.md).
+
+## Choose traversal deliberately
+
+- `len(graph)`, appending, inserting, and removing nodes are efficient operations.
+- Accessing the first or last graph node is constant time; arbitrary indexing is
+  linear time.
+- Use direct graph iteration when only one scope matters.
+- Use `RecursiveGraphIterator` once when nested subgraphs matter instead of
+  repeatedly rediscovering them.
+- Convert nodes to a list or name mapping only when repeated random access
+  justifies the additional memory.
+
+Combine related analyses in a single traversal when practical, but keep
+transformations understandable and preserve accurate invalidation of cached
+metadata.
+
+## Prefer in-place passes
+
+{py:class}`onnx_ir.passes.InPlacePass` avoids cloning the model and is the usual
+choice for transformations. Use functional passes only when preserving the input
+model is part of the API contract.
+
+`model.clone()` creates new graphs, nodes, and values but shares initializer and
+constant tensors. `deep_copy=True` additionally copies analysis metadata; it does
+not imply copying tensor storage.
+
+{py:class}`onnx_ir.GraphView` is cheaper than cloning when an analysis only needs
+a fixed view over existing nodes.
+
+## Batch graph edits
+
+Use value-based rewrites and batch helpers rather than repeated global searches:
+
+- inspect `Value.producer()`, `Value.uses()`, and `Value.consumers()`;
+- use `replace_all_uses_with` for rewiring;
+- remove multiple known nodes in one `graph.remove` call;
+- use `create_value_mapping` once when many name lookups are required.
+
+Graph iterators support mutation, so transformations do not need to copy
+`list(graph)` merely to remove or insert nodes safely.
+
+## Save large weights efficiently
+
+Use `ir.save(..., external_data=...)` to keep large tensors outside the protobuf
+file. Set `max_shard_size_bytes` when storage systems impose file-size limits.
+
+Use `ir.save_safetensors` when safetensors is the desired external-data format.
+This requires `safetensors>=0.7.0` and unique initializer names across graphs and
+subgraphs.
+
+## Measure representative models
+
+Performance depends on graph size, tensor storage, filesystem behavior, and the
+number of full-model traversals. Benchmark the complete pipeline on representative
+models, including load and save when they are part of the production path.

--- a/docs/subgraphs_and_functions.md
+++ b/docs/subgraphs_and_functions.md
@@ -1,0 +1,103 @@
+# Subgraphs and functions
+
+ONNX represents control flow with graph-valued attributes and reusable
+model-local operations with functions. Both contain nodes, but they have different
+ownership, capture, and invocation semantics.
+
+## Nested subgraphs
+
+Operators such as `If`, `Loop`, and `Scan` store graphs in their attributes.
+Subgraphs declare their own inputs, outputs, initializers, and opset imports, and
+may also reference values from an enclosing graph. These references are implicit
+captures rather than declared subgraph inputs.
+
+Use {py:class}`onnx_ir.traversal.RecursiveGraphIterator` to visit a graph and all
+graphs nested in node attributes:
+
+```python
+import onnx_ir as ir
+
+for node in ir.traversal.RecursiveGraphIterator(model.graph):
+    inspect(node)
+```
+
+`model.graph.all_nodes()` is a convenient alias for the same basic traversal.
+Use iterator callbacks when an analysis needs to know when traversal enters or
+exits a graph scope.
+
+## Analyze implicit captures
+
+{py:func}`onnx_ir.analysis.analyze_implicit_usage` reports the outer-scope values
+used by each nested graph:
+
+```python
+implicit_usage = ir.analysis.analyze_implicit_usage(model.graph)
+
+for subgraph, captured_values in implicit_usage.items():
+    print(subgraph.name, [value.name for value in captured_values])
+```
+
+Capture analysis is useful before extraction, cloning, moving a subgraph, or
+rewriting the values visible to a control-flow body.
+
+When cloning a subgraph independently, `graph.clone()` rejects outer-scope values
+by default. Pass `allow_outer_scope_values=True` to preserve references to the
+original enclosing values.
+
+## Model-local functions
+
+A {py:class}`onnx_ir.Function` defines a reusable operator identified by
+`(domain, name, overload)`. A call node invokes it by using the same operator
+identifier.
+
+Functions own a graph internally but should normally be accessed through the
+function object:
+
+```python
+for function in model.functions.values():
+    print(function.identifier())
+    for node in function:
+        inspect(node)
+```
+
+Unlike graph-valued attributes, functions are stored separately on
+`model.functions`; recursive traversal of the main graph does not visit them.
+Whole-model transformations should process functions explicitly.
+
+Functions can declare reference attributes whose values are supplied by call
+nodes. They also carry their own opset imports, which must remain compatible when
+their bodies are copied into another scope.
+
+## Inline function calls
+
+Use {py:class}`onnx_ir.passes.common.InlinePass` to replace calls with cloned
+function bodies:
+
+```python
+import onnx_ir.passes.common as common_passes
+
+result = common_passes.InlinePass()(model)
+model = result.model
+print(result.id_count)
+```
+
+By default, all eligible calls are inlined. Pass a `criteria` callback to select
+which functions to inline. The pass rejects cyclic function dependencies and
+opset conflicts rather than producing an ambiguous model.
+
+`InlinePass` maintains graph connectivity, names, and ordering for the inlined
+body. Do not add normalization passes solely because inlining occurred. Use a
+targeted repair or validation pass only if another transformation in the pipeline
+invalidated the corresponding invariant.
+
+## Scope-aware transformation checklist
+
+Before implementing a transformation, decide whether it applies to:
+
+- only direct nodes in the main graph;
+- the main graph and nested subgraphs;
+- model-local functions and their subgraphs;
+- every scope in the model.
+
+Also account for implicit captures, graph outputs, per-scope opset imports, and
+names inherited from enclosing scopes.

--- a/docs/tensors.md
+++ b/docs/tensors.md
@@ -75,11 +75,27 @@ To create a tensor from objects other than NumPy array, you need to specify the 
 
 Use {py:class}`onnx_ir.StringTensor <onnx_ir.StringTensor>` to create a string tensor.
 
-<!-- TODO(justinchuby): Document make tensor helper -->
+### Convenience tensor constructor
+
+Use {py:func}`onnx_ir.tensor` to create the appropriate tensor implementation
+from Python values, NumPy-compatible arrays, PyTorch tensors, or `TensorProto`:
+
+```python
+weights = ir.tensor(
+    [[1.0, 2.0], [3.0, 4.0]],
+    dtype=ir.DataType.FLOAT,
+    name="weights",
+)
+```
+
+When creating tensors from plain Python values, specify `dtype` when the operator
+requires a particular ONNX element type. Array-backed inputs preserve their
+compatible dtype.
 
 ### Sparse Tensor
 
-Sparse tensors are not yet supported, but they are on our roadmap.
+Sparse tensor types and attributes can be represented, but a general-purpose
+sparse tensor data implementation is not currently provided.
 
 (from-tensorprotos-and-back)=
 ## From `TensorProto`s and back

--- a/docs/writing_passes.md
+++ b/docs/writing_passes.md
@@ -98,10 +98,28 @@ class IdentityEliminationPass(ir.passes.InPlacePass):
             if len(node.outputs) != 1:
                 continue
 
-            node.outputs[0].replace_all_uses_with(
-                node.inputs[0],
+            input_value = node.inputs[0]
+            output_value = node.outputs[0]
+            output_is_graph_output = output_value.is_graph_output()
+
+            # Eliminating this node would collapse two public values into one.
+            if output_is_graph_output and (
+                input_value.is_graph_input() or input_value.is_initializer()
+            ):
+                continue
+
+            if input_value.type is None:
+                input_value.type = output_value.type
+            if input_value.shape is None:
+                input_value.shape = output_value.shape
+
+            output_value.replace_all_uses_with(
+                input_value,
                 replace_graph_outputs=True,
             )
+            if output_is_graph_output:
+                input_value.name = output_value.name
+
             assert node.graph is not None
             node.graph.remove(node, safe=True)
             modified = True
@@ -112,6 +130,8 @@ class IdentityEliminationPass(ir.passes.InPlacePass):
 When replacing or removing values, preserve required type, shape, name, constant,
 and metadata information. Use `safe=True` for node removal so dangling consumers
 or graph outputs are reported rather than silently producing an invalid graph.
+The built-in {py:class}`onnx_ir.passes.common.IdentityEliminationPass` contains
+the complete implementation, including shape merging and logging.
 
 ## Analysis metadata and invalidation
 
@@ -162,11 +182,9 @@ result = pipeline(model)
 The `modified` flag is part of the pass contract. Report it accurately so pass
 managers can detect convergence and callers can avoid unnecessary work.
 
-Passes should preserve unaffected invariants themselves. Do not routinely append
-name fixing, topological sorting, shape inference, or checking to a pipeline.
-Those passes add model traversals and should be included only when an earlier pass
-documents that it may invalidate the corresponding property, or when the caller
-chooses an explicit validation boundary.
+Passes should preserve unaffected invariants themselves. See
+[Preserve invariants and use targeted repair](invariant-preservation)
+for guidance on adding repair or validation passes only when required.
 
 ## Testing a pass
 

--- a/docs/writing_passes.md
+++ b/docs/writing_passes.md
@@ -1,0 +1,181 @@
+# Writing transformation passes
+
+Passes package graph transformations as composable operations over an
+{py:class}`onnx_ir.Model`. A pass returns a
+{py:class}`onnx_ir.passes.PassResult` containing the resulting model and a
+`modified` flag.
+
+Use a pass when a transformation should be reusable, testable, composed with
+other transformations, or guarded by explicit preconditions and postconditions.
+For individual graph-editing operations, see
+[Graph transformation patterns](graph_transformations.md).
+
+## Choose a pass type
+
+Most transformations should inherit from
+{py:class}`onnx_ir.passes.InPlacePass`. An in-place pass mutates and returns the
+same model object.
+
+Use {py:class}`onnx_ir.passes.FunctionalPass` when the input model must remain
+unchanged. A functional pass must return a different model object, typically by
+cloning before transformation:
+
+```python
+import onnx_ir as ir
+
+
+class FunctionalRewrite(ir.passes.FunctionalPass):
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        new_model = model.clone()
+        # Transform new_model.
+        return ir.passes.PassResult(new_model, modified=True)
+```
+
+An existing in-place pass can also be converted into a functional pass with
+{py:func}`onnx_ir.passes.functionalize`.
+
+## Pass lifecycle
+
+The pass infrastructure calls three methods in order:
+
+1. `requires(model)` checks preconditions.
+2. `call(model)` performs the transformation and returns `PassResult`.
+3. `ensures(model)` checks postconditions on the result.
+
+`requires` and `ensures` are optional. Raise
+{py:class}`onnx_ir.passes.PreconditionError` or
+{py:class}`onnx_ir.passes.PostconditionError` when an invariant is not satisfied.
+Other exceptions from these methods are wrapped in the corresponding error type.
+
+```python
+class RequiresOpset13(ir.passes.InPlacePass):
+    def requires(self, model: ir.Model) -> None:
+        if model.graph.opset_imports.get("", 0) < 13:
+            raise ir.passes.PreconditionError("Requires the default opset to be >= 13")
+
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        modified = False
+        # Transform model and update modified.
+        return ir.passes.PassResult(model, modified=modified)
+```
+
+The framework verifies that the returned model identity matches the declared pass
+type. It raises {py:class}`onnx_ir.passes.PassError` if an in-place pass returns a
+new model or a functional pass returns its input model.
+
+## Transform every applicable scope
+
+{py:class}`onnx_ir.traversal.RecursiveGraphIterator` visits a graph and the
+subgraphs stored in node attributes. It does not implicitly process model-local
+functions, which are stored separately.
+
+```python
+def iter_model_nodes(model: ir.Model):
+    yield from ir.traversal.RecursiveGraphIterator(model.graph)
+    for function in model.functions.values():
+        yield from ir.traversal.RecursiveGraphIterator(function)
+```
+
+Not every pass should recurse. Decide explicitly whether the transformation
+applies only to the main graph, to nested subgraphs, to functions, or to all of
+them. Also account for optional node inputs, which are represented by `None`.
+
+## Example: eliminate Identity nodes
+
+This in-place pass processes the main graph, nested subgraphs, and model-local
+functions. Graph iteration remains safe while matching nodes are removed.
+
+```python
+class IdentityEliminationPass(ir.passes.InPlacePass):
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        modified = False
+
+        for node in iter_model_nodes(model):
+            if node.domain != "" or node.op_type != "Identity":
+                continue
+            if len(node.inputs) != 1 or node.inputs[0] is None:
+                continue
+            if len(node.outputs) != 1:
+                continue
+
+            node.outputs[0].replace_all_uses_with(
+                node.inputs[0],
+                replace_graph_outputs=True,
+            )
+            assert node.graph is not None
+            node.graph.remove(node, safe=True)
+            modified = True
+
+        return ir.passes.PassResult(model, modified=modified)
+```
+
+When replacing or removing values, preserve required type, shape, name, constant,
+and metadata information. Use `safe=True` for node removal so dangling consumers
+or graph outputs are reported rather than silently producing an invalid graph.
+
+## Analysis metadata and invalidation
+
+IR objects expose `meta` for arbitrary analysis state that is not serialized.
+When a transformation changes information an analysis depends on, update the
+cached value or mark it invalid:
+
+```python
+value.meta.invalidate("shape_analysis")
+```
+
+The validity of a metadata entry is defined by the analysis that owns it. A value
+of `None` may still be a valid result, so use `meta.is_valid(key)` rather than
+interpreting the stored value itself as a validity flag.
+
+Use `metadata_props` only for string key-value metadata that should be serialized
+into the ONNX model.
+
+## Compose passes
+
+Use {py:class}`onnx_ir.passes.Sequential` to run passes once in order:
+
+```python
+import onnx_ir.passes.common as common_passes
+
+pipeline = ir.passes.Sequential(
+    IdentityEliminationPass(),
+    common_passes.TopologicalSortPass(),
+    common_passes.CheckerPass(),
+)
+result = pipeline(model)
+```
+
+Use {py:class}`onnx_ir.passes.PassManager` to repeat a sequence for a bounded
+number of steps and optionally stop when no pass reports a modification:
+
+```python
+pipeline = ir.passes.PassManager(
+    [
+        IdentityEliminationPass(),
+        common_passes.CommonSubexpressionEliminationPass(),
+    ],
+    steps=5,
+    early_stop=True,
+)
+result = pipeline(model)
+```
+
+The `modified` flag is part of the pass contract. Report it accurately so pass
+managers can detect convergence and callers can avoid unnecessary work.
+
+## Testing a pass
+
+Tests should cover both the transformation and its contract:
+
+- matching and non-matching graphs;
+- graph inputs, outputs, initializers, and optional inputs;
+- nested subgraphs and functions when supported;
+- accurate `modified` values;
+- required precondition and postcondition failures;
+- preservation of names, types, shapes, and metadata;
+- topological order and successful ONNX checking when the output is expected to
+  be a valid model.
+
+Prefer small, directly constructed graphs that make ownership and use-def
+relationships explicit. Compare object identity when checking whether a value was
+rewired; names alone are not sufficient.

--- a/docs/writing_passes.md
+++ b/docs/writing_passes.md
@@ -139,8 +139,7 @@ import onnx_ir.passes.common as common_passes
 
 pipeline = ir.passes.Sequential(
     IdentityEliminationPass(),
-    common_passes.TopologicalSortPass(),
-    common_passes.CheckerPass(),
+    common_passes.CommonSubexpressionEliminationPass(),
 )
 result = pipeline(model)
 ```
@@ -162,6 +161,12 @@ result = pipeline(model)
 
 The `modified` flag is part of the pass contract. Report it accurately so pass
 managers can detect convergence and callers can avoid unnecessary work.
+
+Passes should preserve unaffected invariants themselves. Do not routinely append
+name fixing, topological sorting, shape inference, or checking to a pipeline.
+Those passes add model traversals and should be included only when an earlier pass
+documents that it may invalidate the corresponding property, or when the caller
+chooses an explicit validation boundary.
 
 ## Testing a pass
 


### PR DESCRIPTION
## Summary

- reorganize the docs navigation and move Reliability and Operations after the user and API guides
- add detailed guides for the IR, model construction, graph transformations, passes, subgraphs/functions, performance, and debugging
- expand getting started into an inspect, transform, validate, save, and reload workflow
- cross-link API references with task-oriented guides and document optional symbolic shape inference
- clarify that transformations should preserve invariants and costly repair or validation passes should run only when needed

## Review notes

A rubber-duck review caught and corrected two examples that could silently change public output names. The pass-authoring example now matches the production Identity elimination behavior, and incremental construction explicitly preserves the output interface.