### PR TITLE
Parallelize external data writing and pack densely in declaration order

### DIFF
--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -138,7 +138,7 @@ runs inside the write with the GIL released, so it overlaps with other threads'
 writes instead of serializing behind them.
 
 Peak memory stays bounded regardless of the worker count: at most
-`max_in_flight_bytes` (512MB by default) plus the size of the largest single
+`max_in_flight_bytes` (1GB by default) plus the size of the largest single
 tensor. Lower it when memory is tight:
 
 ```python

--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -133,6 +133,10 @@ ir.save(
 )
 ```
 
+Weights that live on an accelerator benefit the most. The device-to-host copy
+runs inside the write with the GIL released, so it overlaps with other threads'
+writes instead of serializing behind them.
+
 Peak memory stays bounded regardless of the worker count: at most
 `max_in_flight_bytes` (512MB by default) plus the size of the largest single
 tensor. Lower it when memory is tight:

--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -117,6 +117,54 @@ ir.save(
 )
 ```
 
+## Speed up saving with multiple threads
+
+Pass `max_workers` to overlap tensor materialization (lazy tensor evaluation,
+dtype conversion) with disk writes and to write in parallel. This is most
+effective when initializers need work before they can be written, such as a
+`ir.LazyTensor` that casts from `bfloat16`:
+
+```python
+ir.save(
+    model,
+    "model.onnx",
+    external_data="model.data",
+    max_workers=8,
+)
+```
+
+Peak memory stays bounded regardless of the worker count: at most
+`max_in_flight_bytes` (512MB by default) plus the size of the largest single
+tensor. Lower it when memory is tight:
+
+```python
+ir.save(
+    model,
+    "model.onnx",
+    external_data="model.data",
+    max_workers=8,
+    max_in_flight_bytes=64 * 1024**2,
+)
+```
+
+```{note}
+When `max_workers` is greater than 1, the `callback` is called from worker
+threads. Calls are serialized with a lock, so the callback does not need to be
+thread-safe itself, but it is **no longer invoked in `info.index` order**. Write
+progress callbacks as counters rather than assuming `index` increases:
+
+    import threading
+
+    lock = threading.Lock()
+    done = 0
+
+    def callback(tensor, info):
+        global done
+        with lock:
+            done += 1
+            print(f"[{done}/{info.total}] {tensor.name}")
+```
+
 ## Save with safetensors backend
 
 ```python

--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -103,6 +103,21 @@ Notes:
   the destination only after the new data file is complete. A failed write
   leaves the previous file unchanged.
 - Sharded mode is stricter and can raise `FileExistsError` for collisions.
+  This is a preflight check; another process creating a destination shard
+  concurrently can still race with the final replacement.
+
+By default, tensors are stored densely in initializer declaration order, without
+padding between them. Set `alignment=65536` to retain the previous layout, which
+aligns tensors larger than 1 MiB to Windows' 64 KiB allocation granularity:
+
+```python
+ir.save(
+    model,
+    "model.onnx",
+    external_data="model.data",
+    alignment=65536,
+)
+```
 
 ## Save external data with progress callback
 

--- a/docs/model_io.md
+++ b/docs/model_io.md
@@ -99,7 +99,9 @@ Notes:
 
 - `external_data` must be a **relative** path.
 - `max_shard_size_bytes` requires `external_data`.
-- Single-file mode overwrites destination data file.
+- Single-file mode writes in the destination directory and atomically replaces
+  the destination only after the new data file is complete. A failed write
+  leaves the previous file unchanged.
 - Sharded mode is stricter and can raise `FileExistsError` for collisions.
 
 ## Save external data with progress callback

--- a/src/onnx_ir/__init__.py
+++ b/src/onnx_ir/__init__.py
@@ -196,4 +196,4 @@ def __set_module() -> None:
 
 
 __set_module()
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import abc
 import contextlib
 import dataclasses
+import errno
 import heapq
 import logging
 import math
@@ -388,6 +389,9 @@ def _supports_fileno(file: Any) -> bool:
     except Exception:  # pylint: disable=broad-except
         return False
     return True
+
+
+_EXTERNAL_TENSOR_COPY_CHUNK_SIZE = 1024 * 1024
 
 
 def _create_np_array_for_byte_representation(tensor: Tensor) -> np.ndarray:
@@ -903,12 +907,49 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
         self._check_validity()
         self._check_path_containment()
         with open(self.path, "rb") as src:
-            if self._offset is not None:
-                src.seek(self._offset)
+            source_offset = self._offset or 0
             bytes_to_copy = self._length or self.nbytes
-            chunk_size = 1024 * 1024  # 1MB
+            copied = 0
+
+            # Linux can copy file ranges entirely inside the kernel, avoiding
+            # Python byte buffers and userspace round trips. The API is absent
+            # on macOS/Windows and can reject cross-filesystem copies, so keep
+            # the portable chunked path as a transparent fallback.
+            copy_file_range = getattr(os, "copy_file_range", None)
+            if copy_file_range is not None and _supports_fileno(file):
+                file.flush()
+                destination_offset = file.tell()
+                try:
+                    while copied < bytes_to_copy:
+                        copied_now = copy_file_range(
+                            src.fileno(),
+                            file.fileno(),
+                            min(1 << 30, bytes_to_copy - copied),
+                            offset_src=source_offset + copied,
+                            offset_dst=destination_offset + copied,
+                        )
+                        if copied_now == 0:
+                            break
+                        copied += copied_now
+                except OSError as error:
+                    if error.errno not in {
+                        errno.EINVAL,
+                        errno.ENOSYS,
+                        errno.EOPNOTSUPP,
+                        errno.EPERM,
+                        errno.EXDEV,
+                    }:
+                        raise
+                finally:
+                    # Explicit offsets leave the descriptor position unchanged.
+                    # Advance the Python file object so consecutive writes retain
+                    # the same semantics as write().
+                    file.seek(destination_offset + copied)
+
+            src.seek(source_offset + copied)
+            bytes_to_copy -= copied
             while bytes_to_copy > 0:
-                chunk = src.read(min(chunk_size, bytes_to_copy))
+                chunk = src.read(min(_EXTERNAL_TENSOR_COPY_CHUNK_SIZE, bytes_to_copy))
                 if not chunk:
                     failed_at_offset = (self._offset or 0) + (
                         (self._length or self.nbytes) - bytes_to_copy

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -915,6 +915,16 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
         return self.raw[offset : offset + length]
 
     def tofile(self, file) -> None:
+        """Write the external tensor bytes to a binary file-like object.
+
+        Regular files use ``copy_file_range`` when the platform and filesystem
+        support it. Other destinations use a bounded userspace buffer.
+
+        Args:
+            file: A file-like object with a ``write`` method. Objects that also
+                provide ``fileno``, ``flush``, ``tell``, and ``seek`` may use the
+                kernel-copy fast path.
+        """
         self._check_validity()
         self._check_path_containment()
         with open(self.path, "rb") as src:
@@ -929,6 +939,10 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             copy_file_range = getattr(os, "copy_file_range", None)
             if (
                 copy_file_range is not None
+                and all(
+                    callable(getattr(file, method, None))
+                    for method in ("fileno", "flush", "tell", "seek")
+                )
                 and _is_regular_file(src)
                 and _is_regular_file(file)
             ):

--- a/src/onnx_ir/_core.py
+++ b/src/onnx_ir/_core.py
@@ -21,6 +21,7 @@ import logging
 import math
 import mmap
 import os
+import stat
 import sys
 import textwrap
 import typing
@@ -389,6 +390,16 @@ def _supports_fileno(file: Any) -> bool:
     except Exception:  # pylint: disable=broad-except
         return False
     return True
+
+
+def _is_regular_file(file: Any) -> bool:
+    """Return whether a file-like object is backed by a regular file."""
+    if not _supports_fileno(file):
+        return False
+    try:
+        return stat.S_ISREG(os.fstat(file.fileno()).st_mode)
+    except OSError:
+        return False
 
 
 _EXTERNAL_TENSOR_COPY_CHUNK_SIZE = 1024 * 1024
@@ -916,7 +927,11 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             # on macOS/Windows and can reject cross-filesystem copies, so keep
             # the portable chunked path as a transparent fallback.
             copy_file_range = getattr(os, "copy_file_range", None)
-            if copy_file_range is not None and _supports_fileno(file):
+            if (
+                copy_file_range is not None
+                and _is_regular_file(src)
+                and _is_regular_file(file)
+            ):
                 file.flush()
                 destination_offset = file.tell()
                 try:

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import errno
 import io
 import os
 import pathlib
@@ -1009,6 +1010,67 @@ class ExternalTensorTest(unittest.TestCase):
             # Verify the written data matches expected
             expected_data = self.data.tobytes()
             self.assertEqual(written_data, expected_data)
+
+    def test_tofile_uses_copy_file_range_when_available(self):
+        external_tensor = self.model.graph.initializer[1]
+        external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
+        tensor = _core.ExternalTensor(
+            external_info.location,
+            offset=external_info.offset,
+            length=external_info.length,
+            dtype=ir.DataType.FLOAT16,
+            base_dir=self.base_path,
+            name="input2",
+            shape=_core.Shape(external_tensor.dims),
+        )
+        calls = []
+
+        def copy_file_range(src_fd, dst_fd, count, *, offset_src=None, offset_dst=None):
+            calls.append((count, offset_src, offset_dst))
+            data = os.pread(src_fd, count, offset_src)
+            return os.pwrite(dst_fd, data, offset_dst)
+
+        with (
+            tempfile.NamedTemporaryFile() as output,
+            unittest.mock.patch.object(os, "copy_file_range", copy_file_range, create=True),
+        ):
+            output.write(b"prefix")
+            tensor.tofile(output)
+            output.seek(0)
+            written_data = output.read()
+
+        self.assertTrue(calls)
+        self.assertEqual(calls[0][1], external_info.offset)
+        self.assertEqual(calls[0][2], len(b"prefix"))
+        self.assertEqual(written_data, b"prefix" + self.data_float16.tobytes())
+
+    def test_tofile_falls_back_when_copy_file_range_is_unsupported(self):
+        external_tensor = self.model.graph.initializer[0]
+        external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
+        tensor = _core.ExternalTensor(
+            external_info.location,
+            offset=external_info.offset,
+            length=external_info.length,
+            dtype=ir.DataType.FLOAT,
+            base_dir=self.base_path,
+            name="input",
+            shape=_core.Shape(external_tensor.dims),
+        )
+
+        with (
+            tempfile.NamedTemporaryFile() as output,
+            unittest.mock.patch.object(
+                os,
+                "copy_file_range",
+                side_effect=OSError(errno.EXDEV, "cross-device link"),
+                create=True,
+            ),
+        ):
+            tensor.tofile(output)
+            output.seek(0)
+            written_data = output.read()
+
+        self.assertEqual(written_data, self.data.tobytes())
 
     def test_tofile_empty_tensor(self):
         """Test ExternalTensor.tofile() with empty tensor."""

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -1072,6 +1072,75 @@ class ExternalTensorTest(unittest.TestCase):
 
         self.assertEqual(written_data, self.data.tobytes())
 
+    def test_tofile_continues_fallback_after_partial_kernel_copy(self):
+        external_tensor = self.model.graph.initializer[0]
+        external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
+        tensor = _core.ExternalTensor(
+            external_info.location,
+            offset=external_info.offset,
+            length=external_info.length,
+            dtype=ir.DataType.FLOAT,
+            base_dir=self.base_path,
+            name="input",
+            shape=_core.Shape(external_tensor.dims),
+        )
+        call_count = 0
+
+        def copy_file_range(src_fd, dst_fd, count, *, offset_src=None, offset_dst=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise OSError(errno.EXDEV, "cross-device link")
+            data = os.pread(src_fd, min(count, 3), offset_src)
+            return os.pwrite(dst_fd, data, offset_dst)
+
+        with (
+            tempfile.NamedTemporaryFile() as output,
+            unittest.mock.patch.object(os, "copy_file_range", copy_file_range, create=True),
+        ):
+            tensor.tofile(output)
+            output.seek(0)
+            written_data = output.read()
+
+        self.assertEqual(call_count, 2)
+        self.assertEqual(written_data, self.data.tobytes())
+
+    def test_tofile_does_not_use_copy_file_range_for_pipe(self):
+        external_tensor = self.model.graph.initializer[0]
+        external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
+        tensor = _core.ExternalTensor(
+            external_info.location,
+            offset=external_info.offset,
+            length=external_info.length,
+            dtype=ir.DataType.FLOAT,
+            base_dir=self.base_path,
+            name="input",
+            shape=_core.Shape(external_tensor.dims),
+        )
+
+        class PipeBackedBytesIO(io.BytesIO):
+            def __init__(self, file_descriptor):
+                super().__init__()
+                self._file_descriptor = file_descriptor
+
+            def fileno(self):
+                return self._file_descriptor
+
+        read_fd, write_fd = os.pipe()
+        try:
+            output = PipeBackedBytesIO(write_fd)
+            with unittest.mock.patch.object(
+                os,
+                "copy_file_range",
+                side_effect=AssertionError("must not use kernel copy for a pipe"),
+                create=True,
+            ):
+                tensor.tofile(output)
+            self.assertEqual(output.getvalue(), self.data.tobytes())
+        finally:
+            os.close(read_fd)
+            os.close(write_fd)
+
     def test_tofile_empty_tensor(self):
         """Test ExternalTensor.tofile() with empty tensor."""
         expected_array = np.array([], dtype=np.float32)

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -24,6 +24,32 @@ import onnx_ir as ir
 from onnx_ir import _core, _type_casting
 
 
+def _copy_file_range_with_portable_os_calls(
+    src_fd: int,
+    dst_fd: int,
+    count: int,
+    *,
+    offset_src: int | None,
+    offset_dst: int | None,
+) -> int:
+    """Emulate explicit-offset copy_file_range without Unix-only pread/pwrite."""
+    assert offset_src is not None
+    assert offset_dst is not None
+    src_position = os.lseek(src_fd, 0, os.SEEK_CUR)
+    dst_position = os.lseek(dst_fd, 0, os.SEEK_CUR)
+    try:
+        os.lseek(src_fd, offset_src, os.SEEK_SET)
+        data = os.read(src_fd, count)
+        os.lseek(dst_fd, offset_dst, os.SEEK_SET)
+        written = 0
+        while written < len(data):
+            written += os.write(dst_fd, data[written:])
+        return written
+    finally:
+        os.lseek(src_fd, src_position, os.SEEK_SET)
+        os.lseek(dst_fd, dst_position, os.SEEK_SET)
+
+
 class TensorTest(unittest.TestCase):
     def test_initialize(self):
         tensor = _core.Tensor(
@@ -1027,8 +1053,13 @@ class ExternalTensorTest(unittest.TestCase):
 
         def copy_file_range(src_fd, dst_fd, count, *, offset_src=None, offset_dst=None):
             calls.append((count, offset_src, offset_dst))
-            data = os.pread(src_fd, count, offset_src)
-            return os.pwrite(dst_fd, data, offset_dst)
+            return _copy_file_range_with_portable_os_calls(
+                src_fd,
+                dst_fd,
+                count,
+                offset_src=offset_src,
+                offset_dst=offset_dst,
+            )
 
         with (
             tempfile.NamedTemporaryFile() as output,
@@ -1091,8 +1122,13 @@ class ExternalTensorTest(unittest.TestCase):
             call_count += 1
             if call_count > 1:
                 raise OSError(errno.EXDEV, "cross-device link")
-            data = os.pread(src_fd, min(count, 3), offset_src)
-            return os.pwrite(dst_fd, data, offset_dst)
+            return _copy_file_range_with_portable_os_calls(
+                src_fd,
+                dst_fd,
+                min(count, 3),
+                offset_src=offset_src,
+                offset_dst=offset_dst,
+            )
 
         with (
             tempfile.NamedTemporaryFile() as output,

--- a/src/onnx_ir/_core_test.py
+++ b/src/onnx_ir/_core_test.py
@@ -1103,6 +1103,49 @@ class ExternalTensorTest(unittest.TestCase):
 
         self.assertEqual(written_data, self.data.tobytes())
 
+    def test_tofile_falls_back_when_destination_has_no_tell(self):
+        external_tensor = self.model.graph.initializer[0]
+        external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
+        tensor = _core.ExternalTensor(
+            external_info.location,
+            offset=external_info.offset,
+            length=external_info.length,
+            dtype=ir.DataType.FLOAT,
+            base_dir=self.base_path,
+            name="input",
+            shape=_core.Shape(external_tensor.dims),
+        )
+
+        class FileWithoutTell:
+            def __init__(self, file):
+                self._file = file
+
+            def fileno(self):
+                return self._file.fileno()
+
+            def flush(self):
+                return self._file.flush()
+
+            def seek(self, offset, whence=os.SEEK_SET):
+                return self._file.seek(offset, whence)
+
+            def write(self, data):
+                return self._file.write(data)
+
+        with tempfile.NamedTemporaryFile() as output:
+            wrapped_output = FileWithoutTell(output)
+            with unittest.mock.patch.object(
+                os,
+                "copy_file_range",
+                side_effect=AssertionError("kernel copy requires tell()"),
+                create=True,
+            ):
+                tensor.tofile(wrapped_output)
+            output.seek(0)
+            written_data = output.read()
+
+        self.assertEqual(written_data, self.data.tobytes())
+
     def test_tofile_continues_fallback_after_partial_kernel_copy(self):
         external_tensor = self.model.graph.initializer[0]
         external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -47,6 +47,9 @@ def save(
     max_shard_size_bytes: int | None = None,
     callback: Callable[[_protocols.TensorProtocol, _external_data.CallbackInfo], None]
     | None = None,
+    max_workers: int | None = None,
+    alignment: int | None = None,
+    align_threshold: int = 1048576,
 ) -> None:
     """Save an ONNX model to a file.
 
@@ -103,7 +106,21 @@ def save(
             shard file.
             Effective only when ``external_data`` is set.
         callback: A callback function that is called for each tensor that is saved to external data
-            for debugging or logging purposes.
+            for debugging or logging purposes. When ``max_workers`` enables concurrency the
+            callback is serialized with a lock but is no longer invoked in index order.
+        max_workers: Number of threads used to write external data. ``None`` (the default)
+            or ``1`` writes serially. Values above 1 overlap tensor materialization
+            (lazy tensor evaluation, dtype conversion) with disk writes and parallelize
+            both, which is significantly faster for large models. Peak memory stays
+            bounded regardless of the worker count.
+            Effective only when ``external_data`` is set.
+        alignment: Alignment to apply to the offsets of large tensors, in bytes.
+            ``None`` (the default) packs tensors densely with no padding, producing
+            smaller files. When set, offsets are aligned to ``max(4096, alignment)``;
+            65536 matches the Windows allocation granularity used for memory mapping.
+            Effective only when ``external_data`` is set.
+        align_threshold: Only tensors strictly larger than this many bytes are aligned.
+            Ignored when ``alignment`` is ``None``.
 
     Raises:
         ValueError: If the external data path is an absolute path.
@@ -147,6 +164,9 @@ def save(
                 size_threshold_bytes=size_threshold_bytes,
                 max_shard_size_bytes=max_shard_size_bytes,
                 callback=callback,
+                max_workers=max_workers,
+                alignment=alignment,
+                align_threshold=align_threshold,
             )
             proto = serde.serialize_model(model)
             onnx.save(proto, path, format=format)

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -48,6 +48,7 @@ def save(
     callback: Callable[[_protocols.TensorProtocol, _external_data.CallbackInfo], None]
     | None = None,
     max_workers: int | None = None,
+    max_in_flight_bytes: int = _external_data._DEFAULT_MAX_IN_FLIGHT_BYTES,
     alignment: int | None = None,
     align_threshold: int = 1048576,
 ) -> None:
@@ -114,6 +115,11 @@ def save(
             both, which is significantly faster for large models. Peak memory stays
             bounded regardless of the worker count.
             Effective only when ``external_data`` is set.
+        max_in_flight_bytes: Upper bound, in bytes, on the total size of tensors held in
+            memory at once while writing. This caps peak memory use. A tensor larger
+            than this budget is still admitted on its own, so the effective peak is
+            roughly this value plus the size of the largest tensor.
+            Effective only when ``external_data`` and ``max_workers`` are set.
         alignment: Alignment to apply to the offsets of large tensors, in bytes.
             ``None`` (the default) packs tensors densely with no padding, producing
             smaller files. When set, offsets are aligned to ``max(4096, alignment)``;
@@ -165,6 +171,7 @@ def save(
                 max_shard_size_bytes=max_shard_size_bytes,
                 callback=callback,
                 max_workers=max_workers,
+                max_in_flight_bytes=max_in_flight_bytes,
                 alignment=alignment,
                 align_threshold=align_threshold,
             )

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -60,6 +60,10 @@ def save(
     to load the newly saved model, or provide a different external data path that
     is not currently referenced by any tensors in the model.
 
+    .. versionadded:: 1.1.0
+        Added the ``max_workers``, ``max_in_flight_bytes``, ``alignment``, and
+        ``align_threshold`` parameters.
+
     .. tip::
 
         A simple progress bar can be implemented by passing a callback function as the following::

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -64,6 +64,17 @@ def save(
         Added the ``max_workers``, ``max_in_flight_bytes``, ``alignment``, and
         ``align_threshold`` parameters.
 
+    .. versionchanged:: 1.1.0
+        External tensors are packed densely by default instead of aligning tensors
+        larger than 1 MiB to 64 KiB offsets. Pass ``alignment=65536`` to retain the
+        previous layout.
+
+        Single-file external data writes now use a same-filesystem temporary file
+        and atomically replace the destination after a successful write. Failures
+        leave an existing destination unchanged. Replacement preserves symlinks and
+        file permissions, but creates a new inode, so other hardlinks keep the old
+        file contents.
+
     .. tip::
 
         A simple progress bar can be implemented by passing a callback function as the following::
@@ -140,8 +151,8 @@ def save(
             destination shard file already exists on disk. The sharded write
             path never overwrites existing files; delete the conflicting
             files or choose a different external data path to re-save. The
-            single-file path (``max_shard_size_bytes is None``) instead
-            overwrites ``external_data`` unconditionally and never raises here.
+            single-file path (``max_shard_size_bytes is None``) atomically
+            replaces ``external_data`` only after the new file is complete.
     """
     if max_shard_size_bytes is not None and external_data is None:
         raise ValueError(

--- a/src/onnx_ir/_io.py
+++ b/src/onnx_ir/_io.py
@@ -50,7 +50,7 @@ def save(
     max_workers: int | None = None,
     max_in_flight_bytes: int = _external_data._DEFAULT_MAX_IN_FLIGHT_BYTES,
     alignment: int | None = None,
-    align_threshold: int = 1048576,
+    align_threshold: int = _external_data._DEFAULT_ALIGN_THRESHOLD,
 ) -> None:
     """Save an ONNX model to a file.
 
@@ -144,8 +144,8 @@ def save(
             Ignored when ``alignment`` is ``None``.
 
     Raises:
-        ValueError: If the external data path is an absolute path.
-        ValueError: If ``max_shard_size_bytes`` is not greater than 0.
+        ValueError: If the external data path is absolute or a numeric write
+            option is outside its supported range.
         ValueError: If ``max_shard_size_bytes`` is set without ``external_data``.
         FileExistsError: When ``max_shard_size_bytes`` is set and any
             destination shard file already exists on disk. The sharded write

--- a/src/onnx_ir/_safetensors/__init__.py
+++ b/src/onnx_ir/_safetensors/__init__.py
@@ -247,7 +247,7 @@ def _save_file(
 
             # Build tensor_dict for this shard only
             shard_dict: dict[str, Any] = {}
-            for tensor in tensor_shard:
+            for shard_index, tensor in enumerate(tensor_shard):
                 if callback is not None:
                     callback(
                         tensor,
@@ -256,6 +256,8 @@ def _save_file(
                             index=current_index,
                             offset=current_offset,
                             filename=shard_filename,
+                            shard_total=len(tensor_shard),
+                            shard_index=shard_index,
                         ),
                     )
                 assert tensor.name is not None

--- a/src/onnx_ir/_safetensors/__init__.py
+++ b/src/onnx_ir/_safetensors/__init__.py
@@ -18,6 +18,7 @@ from typing import Any
 import packaging.version
 
 import onnx_ir as ir
+from onnx_ir._shard_filename import get_shard_filename
 
 _HEADER_SIZE_NUMBER_SIZE = 8
 # https://github.com/huggingface/safetensors/blob/806426784adb43631e9a1102d4621126bb589347/safetensors/src/tensor.rs#L811
@@ -70,6 +71,12 @@ _IR_DTYPE_TO_SAFETENSORS_DTYPE = {
 }
 
 
+def _get_shard_filename(base_name: str, shard_idx: int, total_shards: int) -> str:
+    # ``.safetensors`` is the complete format suffix. Preserve dotted model
+    # variants such as ``model.fp16`` as part of the stem.
+    return get_shard_filename(base_name, shard_idx, total_shards, suffix_count=1)
+
+
 @functools.lru_cache(maxsize=1)
 def _import_safetensors():
     """Raise an error if safetensors is not installed."""
@@ -90,32 +97,6 @@ def _import_safetensors():
         )
 
     return safetensors
-
-
-def _get_shard_filename(base_name: str, shard_idx: int, total_shards: int) -> str:
-    """Generate a filename for a shard.
-
-    Args:
-        base_name: The base filename (e.g., 'model.safetensors').
-        shard_idx: The index of this shard (1-indexed).
-        total_shards: The total number of shards.
-
-    Returns:
-        The shard filename (e.g., 'model-00001-of-00003.safetensors').
-    """
-    if total_shards == 1:
-        return base_name
-
-    # Extract extension
-    if "." in base_name:
-        name, ext = base_name.rsplit(".", 1)
-        ext = f".{ext}"
-    else:
-        name = base_name
-        ext = ""
-
-    # Always use 5 digits to follow transformers convention
-    return f"{name}-{shard_idx:05d}-of-{total_shards:05d}{ext}"
 
 
 def _shard_tensors(

--- a/src/onnx_ir/_safetensors/_safetensors_test.py
+++ b/src/onnx_ir/_safetensors/_safetensors_test.py
@@ -203,6 +203,20 @@ class SaveSafetensorsTest(unittest.TestCase):
         # All initializers should be in the weight map
         self.assertEqual(len(index_data["weight_map"]), 5)
 
+    def test_sharding_preserves_dotted_model_stem(self):
+        model = _create_large_model_for_sharding()
+        path = os.path.join(self.tmpdir, "model.fp16.onnx")
+
+        ir.save_safetensors(model, path, size_threshold_bytes=0, max_shard_size_bytes=10000)
+
+        shard_files = [
+            filename
+            for filename in os.listdir(self.tmpdir)
+            if filename.endswith(".safetensors")
+        ]
+        self.assertGreater(len(shard_files), 1)
+        self.assertTrue(all(filename.startswith("model.fp16-") for filename in shard_files))
+
     def test_save_safetensors_no_sharding_when_below_threshold(self):
         """Test that no sharding occurs when total size is below threshold."""
         model = _create_simple_model_with_initializers()

--- a/src/onnx_ir/_shard_filename.py
+++ b/src/onnx_ir/_shard_filename.py
@@ -1,0 +1,46 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Shared shard filename generation."""
+
+from __future__ import annotations
+
+import os
+
+
+def _is_extension_suffix(suffix: str) -> bool:
+    extension = suffix[1:]
+    return (
+        bool(extension)
+        and extension[0].isascii()
+        and extension[0].isalpha()
+        and all(
+            character.isascii() and (character.isalnum() or character == "_")
+            for character in extension
+        )
+    )
+
+
+def get_shard_filename(
+    base_name: str,
+    shard_idx: int,
+    total_shards: int,
+    *,
+    suffix_count: int | None = None,
+) -> str:
+    """Insert a shard marker before a filename's extension suffix chain."""
+    if total_shards == 1:
+        return base_name
+
+    dir_name, filename = os.path.split(base_name)
+    name = filename
+    suffixes: list[str] = []
+    while suffix_count is None or len(suffixes) < suffix_count:
+        candidate_name, suffix = os.path.splitext(name)
+        if not suffix or not _is_extension_suffix(suffix):
+            break
+        name = candidate_name
+        suffixes.append(suffix)
+    extension = "".join(reversed(suffixes))
+
+    shard_filename = f"{name}-{shard_idx:05d}-of-{total_shards:05d}{extension}"
+    return os.path.join(dir_name, shard_filename) if dir_name else shard_filename

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -443,6 +443,13 @@ def _write_tensor_with_budget_at(
         budget.release(reservation)
 
 
+def _create_tensor_write_locks(
+    tensors: Sequence[_protocols.TensorProtocol],
+) -> dict[int, threading.Lock]:
+    """Create locks that serialize writes of the same tensor object."""
+    return {id(tensor): threading.Lock() for tensor in tensors}
+
+
 def _write_external_data(
     tensors: Sequence[_protocols.TensorProtocol],
     external_data_infos: Sequence[_ExternalDataInfo],
@@ -451,6 +458,7 @@ def _write_external_data(
     max_workers: int | None = None,
     max_in_flight_bytes: int = _DEFAULT_MAX_IN_FLIGHT_BYTES,
     budget: _ByteBudget | None = None,
+    tensor_write_locks: dict[int, threading.Lock] | None = None,
 ) -> None:
     """Write tensor data to an external file according to information stored in ExternalDataInfo objects.
 
@@ -466,6 +474,8 @@ def _write_external_data(
             when writing concurrently. Ignored when ``budget`` is given.
         budget: An existing byte budget to share across concurrent shard writes so that
             peak memory does not scale with the number of shards.
+        tensor_write_locks: Locks shared by shard writers to prevent concurrent
+            evaluation of the same tensor object.
     """
     requested_path = os.fspath(file_path)
     destination_path = (
@@ -494,6 +504,11 @@ def _write_external_data(
             budget=budget,
             max_workers=max_workers,
             max_in_flight_bytes=max_in_flight_bytes,
+            tensor_write_locks=(
+                tensor_write_locks
+                if tensor_write_locks is not None
+                else _create_tensor_write_locks(tensors)
+            ),
         )
         writer.write()
         # Windows cannot atomically replace a file while one of its mmap handles
@@ -532,6 +547,7 @@ class _ExternalDataWriter:
         budget: _ByteBudget | None,
         max_workers: int | None,
         max_in_flight_bytes: int,
+        tensor_write_locks: dict[int, threading.Lock],
     ) -> None:
         assert len(tensors) == len(external_data_infos), (
             "Number of tensors and external data infos should match"
@@ -544,6 +560,7 @@ class _ExternalDataWriter:
         self._budget = budget
         self._max_workers = max_workers
         self._max_in_flight_bytes = max_in_flight_bytes
+        self._tensor_write_locks = tensor_write_locks
 
     def write(self) -> None:
         """Select the cheapest writer that provides the requested concurrency."""
@@ -569,6 +586,17 @@ class _ExternalDataWriter:
             ),
         )
 
+    def _write_tensor(self, tensor, file, info: _ExternalDataInfo, budget) -> None:
+        """Write one tensor, serializing repeated references to the same object."""
+        with self._tensor_write_locks[id(tensor)]:
+            _write_tensor_with_budget_at(
+                tensor,
+                file,
+                info.offset,
+                info.length,
+                budget,
+            )
+
     def _write_serial(self) -> None:
         """Write sequentially through one file descriptor."""
         with open(self._file_path, "wb") as data_file:
@@ -582,13 +610,7 @@ class _ExternalDataWriter:
                 # A shard may use a serial writer while other shards are written
                 # concurrently. Honor their shared budget here too; otherwise one
                 # tensor per shard can be materialized at once with no byte bound.
-                _write_tensor_with_budget_at(
-                    tensor,
-                    data_file,
-                    tensor_info.offset,
-                    tensor_info.length,
-                    self._budget,
-                )
+                self._write_tensor(tensor, data_file, tensor_info, self._budget)
 
     def _write_parallel(self, max_workers: int) -> None:
         """Write concurrently through one file descriptor per worker.
@@ -638,13 +660,7 @@ class _ExternalDataWriter:
             assert tensor is not None
             with callback_lock:
                 self._invoke_callback(index, tensor, info.offset)
-            _write_tensor_with_budget_at(
-                tensor,
-                _thread_file(),
-                info.offset,
-                info.length,
-                budget,
-            )
+            self._write_tensor(tensor, _thread_file(), info, budget)
 
         try:
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -709,6 +725,7 @@ def convert_tensors_to_external(
     alignment: int | None = None,
     align_threshold: int = _DEFAULT_ALIGN_THRESHOLD,
     _budget: _ByteBudget | None = None,
+    _tensor_write_locks: dict[int, threading.Lock] | None = None,
 ) -> list[_core.ExternalTensor]:
     """Convert a sequence of any TensorProtocol tensors to external tensors.
 
@@ -765,6 +782,7 @@ def convert_tensors_to_external(
         max_workers=max_workers,
         max_in_flight_bytes=max_in_flight_bytes,
         budget=_budget,
+        tensor_write_locks=_tensor_write_locks,
     )
 
     # Create external tensor objects
@@ -795,6 +813,7 @@ def _write_external_tensors(
     # `-- multiple shard files
     #     `-- shard thread pool
     #         `-- one _ExternalDataWriter per shard -> serial or parallel
+    tensor_write_locks = _create_tensor_write_locks(tensors)
     if max_shard_size_bytes is None:
         # Single-file writes atomically replace an existing destination.
         # Sharded writes reject collisions because layouts with different
@@ -808,6 +827,7 @@ def _write_external_tensors(
             max_in_flight_bytes=max_in_flight_bytes,
             alignment=alignment,
             align_threshold=align_threshold,
+            _tensor_write_locks=tensor_write_locks,
         )
 
     tensor_shards = _shard_tensors(tensors, max_shard_size_bytes, alignment, align_threshold)
@@ -876,6 +896,7 @@ def _write_external_tensors(
                     alignment=alignment,
                     align_threshold=align_threshold,
                     _budget=shared_budget,
+                    _tensor_write_locks=tensor_write_locks,
                 )
                 for job_tensors, job_path, job_callback in shard_jobs
             ]
@@ -894,6 +915,7 @@ def _write_external_tensors(
                 max_in_flight_bytes=max_in_flight_bytes,
                 alignment=alignment,
                 align_threshold=align_threshold,
+                _tensor_write_locks=tensor_write_locks,
             )
         )
     return external_tensors

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -93,12 +93,19 @@ class CallbackInfo:
             which callbacks are invoked when saving concurrently.
         offset: The offset of the tensor in the external data file.
         filename: The filename of the external data file.
+        shard_total: The number of tensors in this external data file. ``None``
+            when the writer does not provide per-file progress information.
+        shard_index: The index of this tensor within its external data file.
+            ``None`` when the writer does not provide per-file progress
+            information.
     """
 
     total: int
     index: int
     offset: int
     filename: str
+    shard_total: int | None = None
+    shard_index: int | None = None
 
 
 def _all_tensors(
@@ -189,6 +196,8 @@ def _make_shard_callback(
                 index=index_offset + info.index,
                 offset=info.offset,
                 filename=info.filename,
+                shard_total=info.total,
+                shard_index=info.index,
             ),
         )
 
@@ -478,6 +487,8 @@ def _write_external_data(
                 index=index,
                 offset=offset,
                 filename=filename,
+                shard_total=tensors_count,
+                shard_index=index,
             ),
         )
 

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -511,133 +511,154 @@ def _write_external_data(
         budget: An existing byte budget to share across concurrent shard writes so that
             peak memory does not scale with the number of shards.
     """
-    tensors_count = len(tensors)
-    assert tensors_count == len(external_data_infos), (
-        "Number of tensors and external data infos should match"
+    writer = _ExternalDataWriter(
+        tensors,
+        external_data_infos,
+        file_path,
+        callback,
+        budget=budget,
+        max_workers=max_workers,
+        max_in_flight_bytes=max_in_flight_bytes,
     )
+    writer.write()
 
-    filename = os.path.basename(file_path)
 
-    def _invoke_callback(index: int, tensor: _protocols.TensorProtocol, offset: int) -> None:
-        if callback is None:
+class _ExternalDataWriter:
+    """Coordinate serial or parallel writes to one external data file."""
+
+    def __init__(
+        self,
+        tensors: Sequence[_protocols.TensorProtocol],
+        external_data_infos: Sequence[_ExternalDataInfo],
+        file_path: str | os.PathLike,
+        callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None,
+        *,
+        budget: _ByteBudget | None,
+        max_workers: int | None,
+        max_in_flight_bytes: int,
+    ) -> None:
+        assert len(tensors) == len(external_data_infos), (
+            "Number of tensors and external data infos should match"
+        )
+        self._tensors = tensors
+        self._external_data_infos = external_data_infos
+        self._file_path = file_path
+        self._filename = os.path.basename(file_path)
+        self._callback = callback
+        self._budget = budget
+        self._max_workers = max_workers
+        self._max_in_flight_bytes = max_in_flight_bytes
+
+    def write(self) -> None:
+        """Select the cheapest writer that provides the requested concurrency."""
+        if self._max_workers is not None and self._max_workers > 1 and len(self._tensors) > 1:
+            self._write_parallel(self._max_workers)
+        else:
+            self._write_serial()
+
+    def _invoke_callback(
+        self, index: int, tensor: _protocols.TensorProtocol, offset: int
+    ) -> None:
+        if self._callback is None:
             return
-        callback(
+        self._callback(
             tensor,
             CallbackInfo(
-                total=tensors_count,
+                total=len(self._tensors),
                 index=index,
                 offset=offset,
-                filename=filename,
-                shard_total=tensors_count,
+                filename=self._filename,
+                shard_total=len(self._tensors),
                 shard_index=index,
             ),
         )
 
-    if max_workers is not None and max_workers > 1 and tensors_count > 1:
-        _write_external_data_parallel(
-            tensors,
-            external_data_infos,
-            file_path,
-            _invoke_callback,
-            max_workers=max_workers,
-            max_in_flight_bytes=max_in_flight_bytes,
-            budget=budget,
-        )
-        return
+    def _write_serial(self) -> None:
+        """Write sequentially through one file descriptor."""
+        with open(self._file_path, "wb") as data_file:
+            # Seeking past EOF creates a file hole that reads back as zeros, so
+            # aligned offsets need no explicit padding allocation or write.
+            for i, (tensor, tensor_info) in enumerate(
+                zip(self._tensors, self._external_data_infos, strict=True)
+            ):
+                assert tensor is not None
+                self._invoke_callback(i, tensor, tensor_info.offset)
+                # A shard may use a serial writer while other shards are written
+                # concurrently. Honor their shared budget here too; otherwise one
+                # tensor per shard can be materialized at once with no byte bound.
+                _write_tensor_with_budget_at(
+                    tensor,
+                    data_file,
+                    tensor_info.offset,
+                    tensor_info.length,
+                    self._budget,
+                )
 
-    with open(file_path, "wb") as data_file:
-        # Seeking past EOF creates a file hole that reads back as zeros, so
-        # aligned offsets need no explicit padding allocation or write.
-        for i, (tensor, tensor_info) in enumerate(
-            zip(tensors, external_data_infos, strict=True)
-        ):
+    def _write_parallel(self, max_workers: int) -> None:
+        """Write concurrently through one file descriptor per worker.
+
+        Every tensor's byte range is known up front, so writes have no ordering
+        dependency. The file is preallocated to its final size and each worker
+        opens its own descriptor. A shared byte budget bounds materialized tensor
+        memory while overlapping computation and I/O. Both file writes and tensor
+        materialization release the GIL, so threads can parallelize this work.
+
+        The bytes written are identical to the serial path.
+        """
+        total_size = max(
+            (info.offset + info.length for info in self._external_data_infos),
+            default=0,
+        )
+        # Preallocate so that every worker can seek to its own offset. Gaps between
+        # tensors read back as zeros, matching the sparse holes created serially.
+        with open(self._file_path, "wb") as data_file:
+            data_file.truncate(total_size)
+
+        budget = (
+            self._budget
+            if self._budget is not None
+            else _ByteBudget(self._max_in_flight_bytes)
+        )
+        callback_lock = threading.Lock()
+        thread_local = threading.local()
+        files: list = []
+        files_lock = threading.Lock()
+
+        def _thread_file():
+            data_file = getattr(thread_local, "data_file", None)
+            if data_file is None:
+                # Closed below after all workers are done.
+                data_file = open(  # ruff: ignore[open-file-with-context-handler]
+                    self._file_path, "r+b"
+                )
+                thread_local.data_file = data_file
+                with files_lock:
+                    files.append(data_file)
+            return data_file
+
+        def _write_one(index: int) -> None:
+            tensor = self._tensors[index]
+            info = self._external_data_infos[index]
             assert tensor is not None
-            _invoke_callback(i, tensor, tensor_info.offset)
-            # A shard may use a serial writer while other shards are written
-            # concurrently. Honor their shared budget here too; otherwise one
-            # tensor per shard can be materialized at once with no byte bound.
+            with callback_lock:
+                self._invoke_callback(index, tensor, info.offset)
             _write_tensor_with_budget_at(
                 tensor,
-                data_file,
-                tensor_info.offset,
-                tensor_info.length,
+                _thread_file(),
+                info.offset,
+                info.length,
                 budget,
             )
 
-
-def _write_external_data_parallel(
-    tensors: Sequence[_protocols.TensorProtocol],
-    external_data_infos: Sequence[_ExternalDataInfo],
-    file_path: str | os.PathLike,
-    invoke_callback: Callable[[int, _protocols.TensorProtocol, int], None],
-    *,
-    max_workers: int,
-    max_in_flight_bytes: int,
-    budget: _ByteBudget | None = None,
-) -> None:
-    """Write tensors concurrently to preassigned offsets in ``file_path``.
-
-    Every tensor's byte range is known up front, so writes have no ordering
-    dependency on one another. The file is preallocated to its final size and
-    each worker opens its own file object, giving every thread an independent
-    file position and removing the need for a write lock. Both ``write()`` and
-    the numpy/torch work behind materialization release the GIL, so this
-    overlaps computation with I/O *and* parallelizes each of them.
-
-    Peak memory is bounded by a byte budget rather than a queue length: a worker
-    reserves a tensor's size before materializing it and releases the
-    reservation once the bytes have reached the file.
-
-    The bytes written are identical to the serial path.
-    """
-    total_size = max(
-        (info.offset + info.length for info in external_data_infos),
-        default=0,
-    )
-    # Preallocate so that every worker can seek to its own offset. Gaps between
-    # tensors read back as zeros, matching the sparse holes created serially.
-    with open(file_path, "wb") as data_file:
-        data_file.truncate(total_size)
-
-    budget = budget if budget is not None else _ByteBudget(max_in_flight_bytes)
-    callback_lock = threading.Lock()
-    thread_local = threading.local()
-    files: list = []
-    files_lock = threading.Lock()
-
-    def _thread_file():
-        data_file = getattr(thread_local, "data_file", None)
-        if data_file is None:
-            # Closed in the caller's finally block, after all workers are done.
-            data_file = open(file_path, "r+b")  # ruff: ignore[open-file-with-context-handler]
-            thread_local.data_file = data_file
-            with files_lock:
-                files.append(data_file)
-        return data_file
-
-    def _write_one(index: int) -> None:
-        tensor = tensors[index]
-        info = external_data_infos[index]
-        assert tensor is not None
-        with callback_lock:
-            invoke_callback(index, tensor, info.offset)
-        _write_tensor_with_budget_at(
-            tensor,
-            _thread_file(),
-            info.offset,
-            info.length,
-            budget,
-        )
-
-    try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [executor.submit(_write_one, i) for i in range(len(tensors))]
-            # Surface the first failure while letting the pool unwind cleanly.
-            for future in concurrent.futures.as_completed(futures):
-                future.result()
-    finally:
-        for data_file in files:
-            data_file.close()
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [executor.submit(_write_one, i) for i in range(len(self._tensors))]
+                # Surface the first failure while letting the pool unwind cleanly.
+                for future in concurrent.futures.as_completed(futures):
+                    future.result()
+        finally:
+            for data_file in files:
+                data_file.close()
 
 
 def _create_external_tensor(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -914,8 +914,11 @@ def unload_from_model(
             # both: nesting a pool of that size inside each of that many shard
             # threads would spawn up to ``max_workers ** 2`` threads, breaking
             # the contract that ``max_workers`` bounds the thread count.
+            # The shard driver threads count against the budget too: each one
+            # occupies a thread while its inner pool runs. Reserve them first so
+            # that drivers + inner workers stay within max_workers.
             shard_workers = min(max_workers, len(shard_jobs))
-            workers_per_shard = max(1, max_workers // shard_workers)
+            workers_per_shard = max(1, (max_workers - shard_workers) // shard_workers)
             shared_budget = _ByteBudget(max_in_flight_bytes)
             shard_lock = threading.Lock()
 

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -468,6 +468,25 @@ def _write_tensor_at(
         tensor.release()
 
 
+def _write_tensor_with_budget_at(
+    tensor: _protocols.TensorProtocol,
+    file,
+    offset: int,
+    length: int,
+    budget: _ByteBudget | None,
+) -> None:
+    """Write a tensor while accounting for its userspace memory."""
+    if budget is None:
+        _write_tensor_at(tensor, file, offset)
+        return
+    reservation = budget.acquire(_reservation_bytes(tensor, length))
+    try:
+        _write_tensor_at(tensor, file, offset)
+    finally:
+        # Release the budget if writing fails; the exception still propagates.
+        budget.release(reservation)
+
+
 def _write_external_data(
     tensors: Sequence[_protocols.TensorProtocol],
     external_data_infos: Sequence[_ExternalDataInfo],
@@ -534,18 +553,16 @@ def _write_external_data(
         ):
             assert tensor is not None
             _invoke_callback(i, tensor, tensor_info.offset)
-            if budget is None:
-                _write_tensor_at(tensor, data_file, tensor_info.offset)
-                continue
             # A shard may use a serial writer while other shards are written
             # concurrently. Honor their shared budget here too; otherwise one
             # tensor per shard can be materialized at once with no byte bound.
-            reserved = budget.acquire(_reservation_bytes(tensor, tensor_info.length))
-            try:
-                _write_tensor_at(tensor, data_file, tensor_info.offset)
-            finally:
-                # Release the budget if writing fails; the exception still propagates.
-                budget.release(reserved)
+            _write_tensor_with_budget_at(
+                tensor,
+                data_file,
+                tensor_info.offset,
+                tensor_info.length,
+                budget,
+            )
 
 
 def _write_external_data_parallel(
@@ -577,8 +594,8 @@ def _write_external_data_parallel(
         (info.offset + info.length for info in external_data_infos),
         default=0,
     )
-    # Preallocate so that every worker can seek to its own offset. Holes read
-    # back as zeros, matching the explicit zero padding written serially.
+    # Preallocate so that every worker can seek to its own offset. Gaps between
+    # tensors read back as zeros, matching the sparse holes created serially.
     with open(file_path, "wb") as data_file:
         data_file.truncate(total_size)
 
@@ -604,12 +621,13 @@ def _write_external_data_parallel(
         assert tensor is not None
         with callback_lock:
             invoke_callback(index, tensor, info.offset)
-        reserved = budget.acquire(_reservation_bytes(tensor, info.length))
-        try:
-            _write_tensor_at(tensor, _thread_file(), info.offset)
-        finally:
-            # Release the budget if writing fails; the exception still propagates.
-            budget.release(reserved)
+        _write_tensor_with_budget_at(
+            tensor,
+            _thread_file(),
+            info.offset,
+            info.length,
+            budget,
+        )
 
     try:
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -28,6 +28,7 @@ from collections.abc import Iterator, Sequence
 from onnx_ir import _core, _enums, _protocols
 from onnx_ir import traversal as _traversal
 from onnx_ir._polyfill import zip
+from onnx_ir._shard_filename import get_shard_filename as _get_shard_filename
 
 # Default alignment threshold used when alignment is enabled: only tensors larger
 # than this get their offset aligned, so small initializers don't waste file space.
@@ -59,6 +60,26 @@ def _align_offset(
         return current_offset
     factor = max(4096, alignment)
     return (current_offset + factor - 1) // factor * factor
+
+
+def _validate_write_options(
+    max_workers: int | None,
+    max_in_flight_bytes: int,
+    alignment: int | None,
+    align_threshold: int,
+) -> None:
+    if max_workers is not None and max_workers <= 0:
+        raise ValueError(f"max_workers must be greater than 0, got {max_workers}.")
+    if max_in_flight_bytes <= 0:
+        raise ValueError(
+            f"max_in_flight_bytes must be greater than 0, got {max_in_flight_bytes}."
+        )
+    if alignment is not None and alignment <= 0:
+        raise ValueError(f"alignment must be greater than 0, got {alignment}.")
+    if align_threshold < 0:
+        raise ValueError(
+            f"align_threshold must be greater than or equal to 0, got {align_threshold}."
+        )
 
 
 @dataclasses.dataclass
@@ -158,39 +179,6 @@ def set_base_dir(graph: _core.Graph, base_dir: str | os.PathLike) -> None:
             tensor.base_dir = base_dir
 
 
-def _get_shard_filename(base_name: str, shard_idx: int, total_shards: int) -> str:
-    """Generate a filename for a shard of external data.
-
-    Args:
-        base_name: The base filename (e.g., 'model.data').
-        shard_idx: The index of this shard (1-indexed).
-        total_shards: The total number of shards.
-
-    Returns:
-        The shard filename (e.g., 'model-00001-of-00003.data').
-    """
-    if total_shards == 1:
-        return base_name
-
-    dir_name, filename = os.path.split(base_name)
-    # Preserve the full suffix chain so the shard marker stays attached to the
-    # filename stem: ``model.onnx.data`` becomes
-    # ``model-00001-of-00003.onnx.data``. Repeated splitext calls implement the
-    # same general rule for any compound suffix without importing pathlib.
-    name = filename
-    suffixes = []
-    while True:
-        name, suffix = os.path.splitext(name)
-        if not suffix:
-            break
-        suffixes.append(suffix)
-    ext = "".join(reversed(suffixes))
-
-    # Always use 5 digits to follow transformers convention
-    shard_filename = f"{name}-{shard_idx:05d}-of-{total_shards:05d}{ext}"
-    return os.path.join(dir_name, shard_filename) if dir_name else shard_filename
-
-
 def _make_shard_callback(
     callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None],
     total: int,
@@ -283,21 +271,6 @@ def _external_tensor_to_memory_tensor(
     tensor_data = tensor.numpy().copy()
     tensor.release()
     return _core.Tensor(tensor_data, name=tensor.name, dtype=tensor.dtype)
-
-
-def _estimate_shard_size_bytes(
-    tensors: Sequence[_protocols.TensorProtocol],
-    alignment: int | None = None,
-    align_threshold: int = _DEFAULT_ALIGN_THRESHOLD,
-) -> int:
-    """Estimate the shard file size in bytes for tensors written to one file."""
-    current_offset = 0
-    for tensor in tensors:
-        current_offset = _align_offset(
-            current_offset, tensor.nbytes, alignment, align_threshold
-        )
-        current_offset += tensor.nbytes
-    return current_offset
 
 
 def _paths_refer_to_same_file(path1: str | os.PathLike, path2: str | os.PathLike) -> bool:
@@ -662,12 +635,16 @@ class _ExternalDataWriter:
                 self._invoke_callback(index, tensor, info.offset)
             self._write_tensor(tensor, _thread_file(), info, budget)
 
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
         try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [executor.submit(_write_one, i) for i in range(len(self._tensors))]
-                # Surface the first failure while letting the pool unwind cleanly.
-                for future in concurrent.futures.as_completed(futures):
-                    future.result()
+            futures = [executor.submit(_write_one, i) for i in range(len(self._tensors))]
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
+        except BaseException:
+            executor.shutdown(wait=True, cancel_futures=True)
+            raise
+        else:
+            executor.shutdown(wait=True)
         finally:
             for data_file in files:
                 data_file.close()
@@ -729,6 +706,15 @@ def convert_tensors_to_external(
 ) -> list[_core.ExternalTensor]:
     """Convert a sequence of any TensorProtocol tensors to external tensors.
 
+    .. versionadded:: 1.1.0
+        Added ``max_workers``, ``max_in_flight_bytes``, ``alignment``, and
+        ``align_threshold``.
+
+    .. versionchanged:: 1.1.0
+        Tensors are packed densely in input order by default, and writes now
+        atomically replace the destination after succeeding. Added concurrent
+        writing and optional alignment controls.
+
     Data is written to a temporary file in the destination directory and atomically
     replaces the destination only after the write succeeds. Existing external
     tensors backed by the destination stream directly into the temporary file and
@@ -762,7 +748,11 @@ def convert_tensors_to_external(
     Returns:
         A list of external tensors derived from a list of input tensors. The order
         matches the input tensor order.
+
+    Raises:
+        ValueError: If a numeric write option is outside its supported range.
     """
+    _validate_write_options(max_workers, max_in_flight_bytes, alignment, align_threshold)
     path = os.path.join(base_dir, relative_path)
 
     # Compute external data information for each tensor and write to disk
@@ -964,6 +954,15 @@ def unload_from_model(
 ) -> _core.Model:
     """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to one or more data files.
 
+    .. versionadded:: 1.1.0
+        Added ``max_shard_size_bytes``, ``max_workers``,
+        ``max_in_flight_bytes``, ``alignment``, and ``align_threshold``.
+
+    .. versionchanged:: 1.1.0
+        Initializers are packed densely in declaration order by default.
+        Single-file writes now replace the destination atomically. Added
+        concurrent writing, sharding, and optional alignment controls.
+
     It should only replace the initializers in the model with external tensors
     and not make any other modifications to the model.
 
@@ -1018,7 +1017,7 @@ def unload_from_model(
         converted to external tensors.
 
     Raises:
-        ValueError: If ``max_shard_size_bytes`` is not greater than 0.
+        ValueError: If a numeric write option is outside its supported range.
         FileExistsError: When ``max_shard_size_bytes`` is set and any
             destination shard file already exists on disk. The sharded write
             path never overwrites existing files (re-saving a model whose
@@ -1033,6 +1032,7 @@ def unload_from_model(
         responsibility to clean up. This function will neither delete nor
         rename pre-existing files that are not in the new destination set.
     """
+    _validate_write_options(max_workers, max_in_flight_bytes, alignment, align_threshold)
     if max_shard_size_bytes is not None and max_shard_size_bytes <= 0:
         raise ValueError(
             f"max_shard_size_bytes must be greater than 0, got {max_shard_size_bytes}."

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -173,16 +173,18 @@ def _get_shard_filename(base_name: str, shard_idx: int, total_shards: int) -> st
         return base_name
 
     dir_name, filename = os.path.split(base_name)
-    # ``.onnx.data`` is a conventional compound suffix. Treating only
-    # ``.data`` as the extension would produce
-    # ``model.onnx-00001-of-00003.data``; keep the compound suffix intact so
-    # the shard marker belongs to the model stem instead.
-    compound_suffix = ".onnx.data"
-    if filename.endswith(compound_suffix):
-        name = filename[: -len(compound_suffix)]
-        ext = compound_suffix
-    else:
-        name, ext = os.path.splitext(filename)
+    # Preserve the full suffix chain so the shard marker stays attached to the
+    # filename stem: ``model.onnx.data`` becomes
+    # ``model-00001-of-00003.onnx.data``. Repeated splitext calls implement the
+    # same general rule for any compound suffix without importing pathlib.
+    name = filename
+    suffixes = []
+    while True:
+        name, suffix = os.path.splitext(name)
+        if not suffix:
+            break
+        suffixes.append(suffix)
+    ext = "".join(reversed(suffixes))
 
     # Always use 5 digits to follow transformers convention
     shard_filename = f"{name}-{shard_idx:05d}-of-{total_shards:05d}{ext}"

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -777,6 +777,132 @@ def convert_tensors_to_external(
     ]
 
 
+def _write_external_tensors(
+    tensors: Sequence[_protocols.TensorProtocol],
+    base_dir: str | os.PathLike,
+    relative_path: str | os.PathLike,
+    *,
+    max_shard_size_bytes: int | None,
+    callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None,
+    max_workers: int | None,
+    max_in_flight_bytes: int,
+    alignment: int | None,
+    align_threshold: int,
+) -> list[_core.ExternalTensor]:
+    """Write tensors to one file or coordinate writes across shard files."""
+    # Write strategy:
+    #
+    # tensors
+    # |-- one destination file
+    # |   `-- _ExternalDataWriter -> serial or parallel tensor writes
+    # `-- multiple shard files
+    #     `-- shard thread pool
+    #         `-- one _ExternalDataWriter per shard -> serial or parallel
+    if max_shard_size_bytes is None:
+        # The single-file path keeps its long-standing permissive overwrite
+        # semantics. Sharded writes reject collisions because layouts with
+        # different shard counts have different, potentially ambiguous names.
+        # TODO(justinchuby): both paths should eventually share one policy.
+        return convert_tensors_to_external(
+            tensors,
+            base_dir=base_dir,
+            relative_path=relative_path,
+            callback=callback,
+            max_workers=max_workers,
+            max_in_flight_bytes=max_in_flight_bytes,
+            alignment=alignment,
+            align_threshold=align_threshold,
+        )
+
+    tensor_shards = _shard_tensors(tensors, max_shard_size_bytes, alignment, align_threshold)
+    total_shards = len(tensor_shards)
+    shard_relative_paths = [
+        _get_shard_filename(str(relative_path), shard_idx, total_shards)
+        for shard_idx in range(1, total_shards + 1)
+    ]
+    destination_paths = [
+        os.path.join(base_dir, shard_relative_path)
+        for shard_relative_path in shard_relative_paths
+    ]
+    # No shard may overwrite an existing file. This also guarantees that no
+    # input ExternalTensor is backed by a destination about to be overwritten,
+    # so shard inputs do not need to be staged in memory.
+    _check_no_existing_shard_files(destination_paths)
+
+    shard_jobs: list[
+        tuple[
+            Sequence[_protocols.TensorProtocol],
+            str,
+            Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None,
+        ]
+    ] = []
+    global_index = 0
+    for shard_tensors, shard_relative_path in zip(
+        tensor_shards, shard_relative_paths, strict=True
+    ):
+        shard_callback = (
+            _make_shard_callback(callback, len(tensors), global_index)
+            if callback is not None
+            else None
+        )
+        shard_jobs.append((shard_tensors, shard_relative_path, shard_callback))
+        global_index += len(shard_tensors)
+
+    external_tensors: list[_core.ExternalTensor] = []
+    if max_workers is not None and max_workers > 1 and len(shard_jobs) > 1:
+        # Shard driver threads count toward max_workers. Split the remaining
+        # workers among inner writers instead of nesting max_workers-sized pools.
+        shard_workers = min(max_workers, len(shard_jobs))
+        workers_per_shard = max(1, (max_workers - shard_workers) // shard_workers)
+        shared_budget = _ByteBudget(max_in_flight_bytes)
+        callback_lock = threading.Lock()
+
+        def _locked_callback(
+            inner: Callable[[_protocols.TensorProtocol, CallbackInfo], None],
+        ) -> Callable[[_protocols.TensorProtocol, CallbackInfo], None]:
+            def _wrapped(tensor: _protocols.TensorProtocol, info: CallbackInfo) -> None:
+                with callback_lock:
+                    inner(tensor, info)
+
+            return _wrapped
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=shard_workers) as executor:
+            shard_futures = [
+                executor.submit(
+                    convert_tensors_to_external,
+                    job_tensors,
+                    base_dir=base_dir,
+                    relative_path=job_path,
+                    callback=(
+                        _locked_callback(job_callback) if job_callback is not None else None
+                    ),
+                    max_workers=workers_per_shard,
+                    alignment=alignment,
+                    align_threshold=align_threshold,
+                    _budget=shared_budget,
+                )
+                for job_tensors, job_path, job_callback in shard_jobs
+            ]
+            for shard_future in shard_futures:
+                external_tensors.extend(shard_future.result())
+        return external_tensors
+
+    for job_tensors, job_path, job_callback in shard_jobs:
+        external_tensors.extend(
+            convert_tensors_to_external(
+                job_tensors,
+                base_dir=base_dir,
+                relative_path=job_path,
+                callback=job_callback,
+                max_workers=max_workers,
+                max_in_flight_bytes=max_in_flight_bytes,
+                alignment=alignment,
+                align_threshold=align_threshold,
+            )
+        )
+    return external_tensors
+
+
 def load_to_model(model: _core.Model) -> _core.Model:
     """Convert all external model initializers to memory tensors in-place.
 
@@ -914,140 +1040,21 @@ def unload_from_model(
         [v.const_value for v in initializers_to_load_to_memory]  # type: ignore[misc]
     )
 
-    external_tensors: list[_core.ExternalTensor]
-    if max_shard_size_bytes is None:
-        # No sharding: write all tensors to the single destination file. The
-        # single-file write path keeps its long-standing permissive semantics
-        # of overwriting whatever happens to be at ``relative_path``; the
-        # collision check below is sharded-only because shard layouts are
-        # ambiguous (different shard counts produce different filenames) and
-        # so silent overwrite is much more dangerous there.
-        # TODO(justinchuby): the single-file and sharded paths should
-        # eventually share the same overwrite policy.
-        tensors_to_externalize: list[_protocols.TensorProtocol] = [
-            v.const_value  # type: ignore[misc]
-            for v in initializers_to_become_external
-        ]
-        external_tensors = convert_tensors_to_external(
-            tensors_to_externalize,
-            base_dir=base_dir,
-            relative_path=relative_path,
-            callback=callback,
-            max_workers=max_workers,
-            max_in_flight_bytes=max_in_flight_bytes,
-            alignment=alignment,
-            align_threshold=align_threshold,
-        )
-    else:
-        # Sharding: distribute tensors across multiple numbered shard files
-        tensors_to_externalize = [
-            v.const_value  # type: ignore[misc]
-            for v in initializers_to_become_external
-        ]
-        tensor_shards = _shard_tensors(
-            tensors_to_externalize, max_shard_size_bytes, alignment, align_threshold
-        )
-        total_shards = len(tensor_shards)
-        total_tensors = len(tensors_to_externalize)
-        shard_relative_paths = [
-            _get_shard_filename(str(relative_path), shard_idx, total_shards)
-            for shard_idx in range(1, total_shards + 1)
-        ]
-        destination_paths = [
-            os.path.join(base_dir, shard_relative_path)
-            for shard_relative_path in shard_relative_paths
-        ]
-        # Contract: the sharded write path never overwrites a pre-existing
-        # file. If any destination shard already exists on disk we raise
-        # FileExistsError so the caller cannot silently clobber another
-        # model's shards or leave stale shards behind. Because no destination
-        # is ever overwritten, no input ExternalTensor can be backed by a file
-        # we are about to write — so there is no need to pre-materialize
-        # tensors or stage temporary files before writing the shards.
-        _check_no_existing_shard_files(destination_paths)
-
-        external_tensors = []
-        shard_jobs: list[tuple[Sequence[_protocols.TensorProtocol], str, Callable | None]] = []
-        global_index = 0
-
-        for shard_relative_path, shard_tensor_count in zip(
-            shard_relative_paths,
-            [len(shard) for shard in tensor_shards],
-            strict=True,
-        ):
-            shard_tensors = tensors_to_externalize[
-                global_index : global_index + shard_tensor_count
-            ]
-            # Wrap the callback so that index/total reflect the global position across shards
-            shard_callback: (
-                Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None
-            ) = None
-            if callback is not None:
-                shard_callback = _make_shard_callback(callback, total_tensors, global_index)
-            shard_jobs.append((shard_tensors, shard_relative_path, shard_callback))
-            global_index += shard_tensor_count
-
-        if max_workers is not None and max_workers > 1 and len(shard_jobs) > 1:
-            # Shards are distinct files with no ordering dependency, so they are
-            # written concurrently. They share one byte budget so that peak memory
-            # does not grow with the number of shards.
-            #
-            # Split ``max_workers`` across the two levels instead of using it at
-            # both: nesting a pool of that size inside each of that many shard
-            # threads would spawn up to ``max_workers ** 2`` threads, breaking
-            # the contract that ``max_workers`` bounds the thread count.
-            # The shard driver threads count against the budget too: each one
-            # occupies a thread while its inner pool runs. Reserve them first so
-            # that drivers + inner workers stay within max_workers.
-            shard_workers = min(max_workers, len(shard_jobs))
-            workers_per_shard = max(1, (max_workers - shard_workers) // shard_workers)
-            shared_budget = _ByteBudget(max_in_flight_bytes)
-            shard_lock = threading.Lock()
-
-            def _locked_callback(
-                inner: Callable[[_protocols.TensorProtocol, CallbackInfo], None],
-            ) -> Callable[[_protocols.TensorProtocol, CallbackInfo], None]:
-                def _wrapped(tensor: _protocols.TensorProtocol, info: CallbackInfo) -> None:
-                    with shard_lock:
-                        inner(tensor, info)
-
-                return _wrapped
-
-            with concurrent.futures.ThreadPoolExecutor(max_workers=shard_workers) as executor:
-                shard_futures = [
-                    executor.submit(
-                        convert_tensors_to_external,
-                        job_tensors,
-                        base_dir=base_dir,
-                        relative_path=job_path,
-                        callback=(
-                            _locked_callback(job_callback)
-                            if job_callback is not None
-                            else None
-                        ),
-                        max_workers=workers_per_shard,
-                        alignment=alignment,
-                        align_threshold=align_threshold,
-                        _budget=shared_budget,
-                    )
-                    for job_tensors, job_path, job_callback in shard_jobs
-                ]
-                for shard_future in shard_futures:
-                    external_tensors.extend(shard_future.result())
-        else:
-            for job_tensors, job_path, job_callback in shard_jobs:
-                external_tensors.extend(
-                    convert_tensors_to_external(
-                        job_tensors,
-                        base_dir=base_dir,
-                        relative_path=job_path,
-                        callback=job_callback,
-                        max_workers=max_workers,
-                        max_in_flight_bytes=max_in_flight_bytes,
-                        alignment=alignment,
-                        align_threshold=align_threshold,
-                    )
-                )
+    tensors_to_externalize: list[_protocols.TensorProtocol] = [
+        v.const_value  # type: ignore[misc]
+        for v in initializers_to_become_external
+    ]
+    external_tensors = _write_external_tensors(
+        tensors_to_externalize,
+        base_dir,
+        relative_path,
+        max_shard_size_bytes=max_shard_size_bytes,
+        callback=callback,
+        max_workers=max_workers,
+        max_in_flight_bytes=max_in_flight_bytes,
+        alignment=alignment,
+        align_threshold=align_threshold,
+    )
 
     # Replace the initializer values with external tensors and save the model
     for value, external_tensor in zip(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -16,9 +16,12 @@ __all__ = [
 ]
 
 import concurrent.futures
+import contextlib
 import dataclasses
 import logging
 import os
+import shutil
+import tempfile
 import threading
 from collections.abc import Iterator, Sequence
 
@@ -313,48 +316,6 @@ def _paths_refer_to_same_file(path1: str | os.PathLike, path2: str | os.PathLike
         return False
 
 
-def _materialize_external_tensors_for_destination_paths(
-    tensors: Sequence[_protocols.TensorProtocol],
-    destination_paths: Sequence[str | os.PathLike],
-) -> list[_protocols.TensorProtocol]:
-    """Load into memory any external tensor whose backing file is about to be overwritten or deleted.
-
-    Safety-critical: this is what allows ``unload_from_model`` to re-save a
-    loaded sharded model — even when the new shard layout differs from the
-    old one — without reading from a file that has already been clobbered or
-    cleaned up. Callers must pass *every* path that will be written, renamed,
-    or deleted by the upcoming save, not just the immediate destination.
-    """
-    existing_destination_paths = [path for path in destination_paths if os.path.exists(path)]
-    if not existing_destination_paths:
-        return list(tensors)
-
-    converted_tensors: list[_protocols.TensorProtocol] = []
-    for tensor in tensors:
-        if isinstance(tensor, _core.ExternalTensor) and any(
-            _paths_refer_to_same_file(tensor.path, destination_path)
-            for destination_path in existing_destination_paths
-        ):
-            # TODO(justinchuby): If there is a non-initializer tensor that
-            # is referring to this file, that tensor is now invalid.
-            # This is a special case we are ok not handling right now.
-            converted_tensors.append(_external_tensor_to_memory_tensor(tensor))
-            # Mark the original external tensor as invalid because it is now pointing
-            # to a file that is going to be overwritten.
-            tensor.invalidate()
-            logger.warning(
-                "External tensor %s is referring to the destination path. "
-                "It has been invalidated because the data file is changed. To avoid this, "
-                "save the external data to a different path or load the newly saved model back "
-                "with ir.load().",
-                tensor,
-            )
-        else:
-            converted_tensors.append(tensor)
-
-    return converted_tensors
-
-
 def _check_no_existing_shard_files(
     destination_paths: Sequence[str | os.PathLike],
 ) -> None:
@@ -511,16 +472,51 @@ def _write_external_data(
         budget: An existing byte budget to share across concurrent shard writes so that
             peak memory does not scale with the number of shards.
     """
-    writer = _ExternalDataWriter(
-        tensors,
-        external_data_infos,
-        file_path,
-        callback,
-        budget=budget,
-        max_workers=max_workers,
-        max_in_flight_bytes=max_in_flight_bytes,
+    requested_path = os.fspath(file_path)
+    destination_path = (
+        os.path.realpath(requested_path) if os.path.islink(requested_path) else requested_path
     )
-    writer.write()
+    destination_dir = os.path.dirname(destination_path) or "."
+    temporary_dir = tempfile.mkdtemp(
+        dir=destination_dir,
+        prefix=f".{os.path.basename(destination_path)}.",
+    )
+    temporary_path = os.path.join(temporary_dir, os.path.basename(destination_path))
+
+    overwritten_tensors = [
+        tensor
+        for tensor in tensors
+        if isinstance(tensor, _core.ExternalTensor)
+        and _paths_refer_to_same_file(tensor.path, destination_path)
+    ]
+    try:
+        writer = _ExternalDataWriter(
+            tensors,
+            external_data_infos,
+            temporary_path,
+            callback,
+            callback_filename=os.path.basename(requested_path),
+            budget=budget,
+            max_workers=max_workers,
+            max_in_flight_bytes=max_in_flight_bytes,
+        )
+        writer.write()
+        if os.path.exists(destination_path):
+            shutil.copymode(destination_path, temporary_path)
+        os.replace(temporary_path, destination_path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(temporary_path)
+        with contextlib.suppress(FileNotFoundError):
+            os.rmdir(temporary_dir)
+
+    for tensor in overwritten_tensors:
+        tensor.invalidate()
+        logger.warning(
+            "External tensor %s referred to the overwritten destination and has "
+            "been invalidated. Load the newly saved model to obtain a valid tensor.",
+            tensor,
+        )
 
 
 class _ExternalDataWriter:
@@ -533,6 +529,7 @@ class _ExternalDataWriter:
         file_path: str | os.PathLike,
         callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None,
         *,
+        callback_filename: str,
         budget: _ByteBudget | None,
         max_workers: int | None,
         max_in_flight_bytes: int,
@@ -543,7 +540,7 @@ class _ExternalDataWriter:
         self._tensors = tensors
         self._external_data_infos = external_data_infos
         self._file_path = file_path
-        self._filename = os.path.basename(file_path)
+        self._filename = callback_filename
         self._callback = callback
         self._budget = budget
         self._max_workers = max_workers
@@ -716,8 +713,10 @@ def convert_tensors_to_external(
 ) -> list[_core.ExternalTensor]:
     """Convert a sequence of any TensorProtocol tensors to external tensors.
 
-    Existing external tensors are loaded to memory if they are referring to the
-    same file path as the destination path.
+    Data is written to a temporary file in the destination directory and atomically
+    replaces the destination only after the write succeeds. Existing external
+    tensors backed by the destination stream directly into the temporary file and
+    are invalidated after replacement.
 
     Tensors are written in the order they are given, packed densely unless
     ``alignment`` is set. Preserving the input order matters: initializers are
@@ -749,7 +748,6 @@ def convert_tensors_to_external(
         matches the input tensor order.
     """
     path = os.path.join(base_dir, relative_path)
-    tensors = _materialize_external_tensors_for_destination_paths(tensors, [path])
 
     # Compute external data information for each tensor and write to disk
     external_data_infos: list[_ExternalDataInfo] = []
@@ -799,10 +797,9 @@ def _write_external_tensors(
     #     `-- shard thread pool
     #         `-- one _ExternalDataWriter per shard -> serial or parallel
     if max_shard_size_bytes is None:
-        # The single-file path keeps its long-standing permissive overwrite
-        # semantics. Sharded writes reject collisions because layouts with
-        # different shard counts have different, potentially ambiguous names.
-        # TODO(justinchuby): both paths should eventually share one policy.
+        # Single-file writes atomically replace an existing destination.
+        # Sharded writes reject collisions because layouts with different
+        # shard counts have different, potentially ambiguous names.
         return convert_tensors_to_external(
             tensors,
             base_dir=base_dir,
@@ -1006,8 +1003,8 @@ def unload_from_model(
             path never overwrites existing files (re-saving a model whose
             shards already exist therefore requires deleting them first or
             choosing a different external data path). The single-file path
-            (``max_shard_size_bytes is None``) instead overwrites
-            ``relative_path`` unconditionally.
+            (``max_shard_size_bytes is None``) atomically replaces
+            ``relative_path`` only after the new file is complete.
 
     Notes:
         Stale shards from a previous save (when the new layout produces

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -80,9 +80,17 @@ class _ExternalDataInfo:
 class CallbackInfo:
     """A class that shares information about a tensor that is to be saved as external data for callback functions.
 
+    .. note::
+        When saving with ``max_workers`` greater than 1, callbacks are invoked
+        from worker threads. Calls are serialized with a lock, so the callback
+        itself does not need to be thread-safe, but they are **not** delivered in
+        ``index`` order. Progress reporting should count invocations rather than
+        rely on ``index`` increasing monotonically.
+
     Attributes:
         total: The total number of tensors to save.
-        index: The index of the tensor being saved.
+        index: The index of the tensor being saved. Not necessarily the order in
+            which callbacks are invoked when saving concurrently.
         offset: The offset of the tensor in the external data file.
         filename: The filename of the external data file.
     """

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -503,7 +503,17 @@ def _write_external_data(
             file_size = data_file.tell()
             if tensor_info.offset > file_size:
                 data_file.write(b"\0" * (tensor_info.offset - file_size))
-            _write_tensor_at(tensor, data_file, tensor_info.offset)
+            if budget is None:
+                _write_tensor_at(tensor, data_file, tensor_info.offset)
+                continue
+            # A shard may use a serial writer while other shards are written
+            # concurrently. Honor their shared budget here too; otherwise one
+            # tensor per shard can be materialized at once with no byte bound.
+            reserved = budget.acquire(tensor_info.length)
+            try:
+                _write_tensor_at(tensor, data_file, tensor_info.offset)
+            finally:
+                budget.release(reserved)
 
 
 def _write_external_data_parallel(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -532,10 +532,6 @@ def _write_external_data(
         ):
             assert tensor is not None
             _invoke_callback(i, tensor, tensor_info.offset)
-            # Pad the file up to the target offset if needed
-            file_size = data_file.tell()
-            if tensor_info.offset > file_size:
-                data_file.write(b"\0" * (tensor_info.offset - file_size))
             if budget is None:
                 _write_tensor_at(tensor, data_file, tensor_info.offset)
                 continue

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -34,7 +34,7 @@ _DEFAULT_ALIGN_THRESHOLD = 1048576  # 1MB
 _DEFAULT_ALLOCATION_GRANULARITY = 65536  # 64KB
 # Default upper bound on materialized tensor bytes held in memory while writing
 # external data concurrently. Peak memory is this plus the largest single tensor.
-_DEFAULT_MAX_IN_FLIGHT_BYTES = 1 << 29  # 512MB
+_DEFAULT_MAX_IN_FLIGHT_BYTES = 1 << 30  # 1GB
 
 
 logger = logging.getLogger(__name__)
@@ -405,36 +405,40 @@ class _ByteBudget:
 
     Limiting the number of *items* in flight is not enough because a single
     tensor can be many gigabytes. Limiting bytes gives a hard bound on peak
-    memory of ``capacity + max(tensor.nbytes)``: a tensor larger than the whole
-    budget is admitted alone (otherwise it could never be admitted at all).
+    memory of ``capacity + max(tensor.nbytes)``. At most one tensor larger than
+    the whole budget is admitted at a time, alongside regular reservations up
+    to ``capacity``. This keeps the pipeline moving while the oversized tensor
+    is written without allowing multiple oversized tensors to accumulate.
     """
 
     def __init__(self, capacity: int) -> None:
         self._capacity = max(capacity, 1)
         self._in_flight = 0
+        self._oversized_active = False
         self._condition = threading.Condition()
-
-    def _clamp(self, nbytes: int) -> int:
-        return min(max(nbytes, 0), self._capacity)
 
     def acquire(self, nbytes: int) -> int:
         """Reserve ``nbytes`` of budget, blocking until it fits.
 
-        Returns the clamped amount that must be passed back to :meth:`release`.
+        Returns a reservation token that must be passed back to
+        :meth:`release`. ``-1`` represents the single oversized reservation.
         """
-        amount = self._clamp(nbytes)
+        amount = max(nbytes, 0)
         with self._condition:
-            # ``self._in_flight == 0`` lets an oversized tensor through instead
-            # of deadlocking forever waiting for a budget it can never fit in.
-            self._condition.wait_for(
-                lambda: self._in_flight + amount <= self._capacity or self._in_flight == 0
-            )
+            if amount > self._capacity:
+                self._condition.wait_for(lambda: not self._oversized_active)
+                self._oversized_active = True
+                return -1
+            self._condition.wait_for(lambda: self._in_flight + amount <= self._capacity)
             self._in_flight += amount
         return amount
 
-    def release(self, amount: int) -> None:
+    def release(self, reservation: int) -> None:
         with self._condition:
-            self._in_flight -= amount
+            if reservation == -1:
+                self._oversized_active = False
+            else:
+                self._in_flight -= reservation
             self._condition.notify_all()
 
 

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -15,27 +15,50 @@ __all__ = [
     "CallbackInfo",
 ]
 
+import concurrent.futures
 import dataclasses
 import logging
 import os
+import threading
 from collections.abc import Iterator, Sequence
 
 from onnx_ir import _core, _enums, _protocols
 from onnx_ir import traversal as _traversal
 from onnx_ir._polyfill import zip
 
-# Note: If needed in future, add these as parameters to the function calls
-# align_offset: Offset will always be page aligned and alloction granularity aligned for mmap support. This is done by padding previous tensor data with zeros keeping same length. Tensor data will be aligned if > align_threshold
-_ALIGN_OFFSET = True
-# align_threshold: Alignment threshold for size of data. Having a low threshold will waste file space for small initializers. Only when tensor's data is > the page_align_threshold it will be force aligned.
-_ALIGN_THRESHOLD = 1048576  # 1MB
-# allocation_granularity: The allocation Granularity for mmap() support. Typically 64KB for Windows & 4KB for other OSes.
-_ALLOCATION_GRANULARITY = 65536  # 64KB
-# The factor that tensor offsets are aligned to when alignment is enabled.
-_ALIGNMENT_FACTOR = max(4096, _ALLOCATION_GRANULARITY)
+# Default alignment threshold used when alignment is enabled: only tensors larger
+# than this get their offset aligned, so small initializers don't waste file space.
+_DEFAULT_ALIGN_THRESHOLD = 1048576  # 1MB
+# Default allocation granularity for mmap() support. Typically 64KB on Windows
+# and 4KB elsewhere; 64KB is the safe cross-platform choice.
+_DEFAULT_ALLOCATION_GRANULARITY = 65536  # 64KB
+# Default upper bound on materialized tensor bytes held in memory while writing
+# external data concurrently. Peak memory is this plus the largest single tensor.
+_DEFAULT_MAX_IN_FLIGHT_BYTES = 1 << 29  # 512MB
 
 
 logger = logging.getLogger(__name__)
+
+
+def _align_offset(
+    current_offset: int, tensor_size: int, alignment: int | None, align_threshold: int
+) -> int:
+    """Return the offset at which a tensor of ``tensor_size`` bytes should start.
+
+    Alignment used to be applied unconditionally because ONNX Runtime refused to
+    memory-map a tensor whose offset was not a multiple of the allocation
+    granularity. ORT now rounds the offset down to the containing page or
+    allocation block itself, so alignment is no longer required for correctness.
+    Dense packing produces smaller files and matches what safetensors does, so
+    ``alignment=None`` is the default.
+    """
+    if alignment is None:
+        return current_offset
+    if tensor_size <= align_threshold:
+        # Aligning small initializers wastes file space for no benefit.
+        return current_offset
+    factor = max(4096, alignment)
+    return (current_offset + factor - 1) // factor * factor
 
 
 @dataclasses.dataclass
@@ -164,88 +187,32 @@ def _make_shard_callback(
     return _shard_callback
 
 
-@dataclasses.dataclass
-class _ShardSizeAccumulator:
-    """Incrementally track the on-disk size of a shard in O(1) per tensor.
-
-    The size matches :func:`_estimate_shard_size_bytes` (tensors written in
-    size-sorted order with offset alignment) but is maintained incrementally so
-    that sharding does not need to re-sort the shard on every tensor append.
-
-    Load-bearing invariants:
-
-    * :func:`convert_tensors_to_external` writes tensors in ascending-``nbytes``
-      order, so every *unaligned* tensor (``nbytes <= _ALIGN_THRESHOLD``) is
-      written strictly before every *aligned* tensor (``nbytes > _ALIGN_THRESHOLD``).
-      The final on-disk size therefore only depends on a few running aggregates,
-      not on the order in which we observe the tensors here.
-    * Because aligned tensors are written largest-last, the largest aligned
-      tensor sits at the end of the file and contributes only its raw
-      (unpadded) length — that's why ``size`` subtracts
-      ``largest_aligned_padded`` and adds back ``largest_aligned_raw``.
-    * The transition from the unaligned prefix to the first aligned tensor
-      forces the writer to pad up to the next alignment boundary, which the
-      ``leading`` computation accounts for.
-    """
-
-    sum_unaligned: int = 0
-    # ``sum_aligned_padded`` is the *padded* (aligned) total for every aligned
-    # tensor seen so far. The last aligned tensor's padding is subtracted in
-    # ``size`` because it's written last and never followed by another tensor.
-    sum_aligned_padded: int = 0
-    largest_aligned_raw: int = 0
-    largest_aligned_padded: int = 0
-
-    def add(self, tensor: _protocols.TensorProtocol) -> None:
-        size = tensor.nbytes
-        if _ALIGN_OFFSET and size > _ALIGN_THRESHOLD:
-            padded = (size + _ALIGNMENT_FACTOR - 1) // _ALIGNMENT_FACTOR * _ALIGNMENT_FACTOR
-            self.sum_aligned_padded += padded
-            if size >= self.largest_aligned_raw:
-                self.largest_aligned_raw = size
-                self.largest_aligned_padded = padded
-        else:
-            self.sum_unaligned += size
-
-    @property
-    def size(self) -> int:
-        if self.largest_aligned_raw == 0:
-            return self.sum_unaligned
-        # The first aligned tensor pads the unaligned prefix up to an alignment
-        # boundary; the largest aligned tensor is written last and is not padded.
-        leading = (
-            (self.sum_unaligned + _ALIGNMENT_FACTOR - 1)
-            // _ALIGNMENT_FACTOR
-            * _ALIGNMENT_FACTOR
-        )
-        return (
-            leading
-            + self.sum_aligned_padded
-            - self.largest_aligned_padded
-            + self.largest_aligned_raw
-        )
-
-
 def _shard_tensors(
     tensors: Sequence[_protocols.TensorProtocol],
     max_shard_size_bytes: int,
+    alignment: int | None = None,
+    align_threshold: int = _DEFAULT_ALIGN_THRESHOLD,
 ) -> list[list[_protocols.TensorProtocol]]:
     """Shard tensors into multiple groups based on max_shard_size_bytes.
 
-    Each tensor is always placed in exactly one shard. A new shard is started when
-    adding the next tensor would exceed the limit once the shard is written using
-    the same layout as :func:`convert_tensors_to_external` (size-sorted write order
-    plus offset alignment).
+    Each tensor is always placed in exactly one shard, in declaration order. A new
+    shard is started when adding the next tensor would exceed the limit. Without
+    alignment a shard's on-disk size is simply the sum of its tensor sizes; with
+    alignment the padding inserted before large tensors is accounted for too.
 
     Args:
         tensors: The tensors to shard.
         max_shard_size_bytes: Maximum cumulative size in bytes for each shard.
+        alignment: Alignment in bytes for the offsets of large tensors, or ``None``
+            for dense packing.
+        align_threshold: Only tensors strictly larger than this many bytes are
+            aligned. Ignored when ``alignment`` is ``None``.
 
     Returns:
         A list of tensor groups, one per shard.
     """
     shards: list[list[_protocols.TensorProtocol]] = [[]]
-    accumulator = _ShardSizeAccumulator()
+    shard_size = 0
 
     for tensor in tensors:
         if tensor.nbytes > max_shard_size_bytes:
@@ -255,18 +222,16 @@ def _shard_tensors(
                 tensor.nbytes,
                 max_shard_size_bytes,
             )
-        candidate = dataclasses.replace(accumulator)
-        candidate.add(tensor)
+        offset = shard_size
+        offset = _align_offset(offset, tensor.nbytes, alignment, align_threshold)
         # Start a new shard when the current one would be exceeded
         # (but never leave a shard empty).
-        if candidate.size > max_shard_size_bytes and len(shards[-1]) > 0:
+        if offset + tensor.nbytes > max_shard_size_bytes and shards[-1]:
             shards.append([])
-            accumulator = _ShardSizeAccumulator()
-            accumulator.add(tensor)
-        else:
-            accumulator = candidate
+            offset = 0
 
         shards[-1].append(tensor)
+        shard_size = offset + tensor.nbytes
 
     return shards
 
@@ -292,38 +257,17 @@ def _external_tensor_to_memory_tensor(
     return _core.Tensor(tensor_data, name=tensor.name, dtype=tensor.dtype)
 
 
-def _compute_new_offset(
-    current_offset: int,
-    tensor_size: int,
-    align_offset: bool = _ALIGN_OFFSET,
-    align_threshold: int = _ALIGN_THRESHOLD,
-    allocation_granularity: int = _ALLOCATION_GRANULARITY,
+def _estimate_shard_size_bytes(
+    tensors: Sequence[_protocols.TensorProtocol],
+    alignment: int | None = None,
+    align_threshold: int = _DEFAULT_ALIGN_THRESHOLD,
 ) -> int:
-    """Compute the offset to align the tensor data based on the current offset.
-
-    Args:
-        current_offset: Current location in the file at which tensor data will be written to.
-        tensor_size: Size of the tensor data to be written to file.
-        align_offset: Offset will always be page aligned and alloction granularity aligned for mmap support. This is done by padding previous tensor data with zeros keeping same length. Tensor data will be aligned if > align_threshold
-        align_threshold: Alignment threshold for size of data. Having a low threshold will waste file space for small initializers. Only when tensor's data is > the page_align_threshold it will be force aligned.
-        allocation_granularity: The allocation Granularity for mmap() support. Typically 64KB for Windows & 4KB for other OSes.
-
-    Returns:
-        The updated offset value.
-    """
-    if align_offset and tensor_size > align_threshold:
-        alignment_factor = max(4096, allocation_granularity)
-        # Align to the next page or alloc granularity
-        return (current_offset + alignment_factor - 1) // alignment_factor * alignment_factor
-    return current_offset
-
-
-def _estimate_shard_size_bytes(tensors: Sequence[_protocols.TensorProtocol]) -> int:
     """Estimate the shard file size in bytes for tensors written to one file."""
     current_offset = 0
-    sorted_tensors = sorted(tensors, key=lambda tensor: tensor.nbytes)
-    for tensor in sorted_tensors:
-        current_offset = _compute_new_offset(current_offset, tensor.nbytes)
+    for tensor in tensors:
+        current_offset = _align_offset(
+            current_offset, tensor.nbytes, alignment, align_threshold
+        )
         current_offset += tensor.nbytes
     return current_offset
 
@@ -415,11 +359,12 @@ def _check_no_existing_shard_files(
 def _compute_external_data_info(
     tensor: _protocols.TensorProtocol,
     current_offset: int,
+    alignment: int | None = None,
+    align_threshold: int = _DEFAULT_ALIGN_THRESHOLD,
 ) -> _ExternalDataInfo:
     """Capture information about a tensor that is to be stored as external data."""
     tensor_size = tensor.nbytes
-    # Calculate updated offset and align tensors
-    current_offset = _compute_new_offset(current_offset, tensor_size)
+    current_offset = _align_offset(current_offset, tensor_size, alignment, align_threshold)
     # Store offset and tensor size as ExternalDataInfo
     external_data_info = _ExternalDataInfo(
         tensor.name,
@@ -429,11 +374,69 @@ def _compute_external_data_info(
     return external_data_info
 
 
+class _ByteBudget:
+    """Bound the number of materialized bytes held in memory at any one time.
+
+    Limiting the number of *items* in flight is not enough because a single
+    tensor can be many gigabytes. Limiting bytes gives a hard bound on peak
+    memory of ``capacity + max(tensor.nbytes)``: a tensor larger than the whole
+    budget is admitted alone (otherwise it could never be admitted at all).
+    """
+
+    def __init__(self, capacity: int) -> None:
+        self._capacity = max(capacity, 1)
+        self._in_flight = 0
+        self._condition = threading.Condition()
+
+    def _clamp(self, nbytes: int) -> int:
+        return min(max(nbytes, 0), self._capacity)
+
+    def acquire(self, nbytes: int) -> int:
+        """Reserve ``nbytes`` of budget, blocking until it fits.
+
+        Returns the clamped amount that must be passed back to :meth:`release`.
+        """
+        amount = self._clamp(nbytes)
+        with self._condition:
+            # ``self._in_flight == 0`` lets an oversized tensor through instead
+            # of deadlocking forever waiting for a budget it can never fit in.
+            self._condition.wait_for(
+                lambda: self._in_flight + amount <= self._capacity or self._in_flight == 0
+            )
+            self._in_flight += amount
+        return amount
+
+    def release(self, amount: int) -> None:
+        with self._condition:
+            self._in_flight -= amount
+            self._condition.notify_all()
+
+
+def _write_tensor_at(
+    tensor: _protocols.TensorProtocol,
+    file,
+    offset: int,
+) -> None:
+    """Write one tensor's bytes at an absolute ``offset`` in an open binary file."""
+    file.seek(offset)
+    if hasattr(tensor, "tofile"):
+        # Some existing implementation of TensorProtocol
+        # may not have tofile() as it was introduced in v0.1.11
+        tensor.tofile(file)
+    else:
+        file.write(tensor.tobytes())
+    if isinstance(tensor, _core.ExternalTensor):
+        tensor.release()
+
+
 def _write_external_data(
     tensors: Sequence[_protocols.TensorProtocol],
     external_data_infos: Sequence[_ExternalDataInfo],
     file_path: str | os.PathLike,
     callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
+    max_workers: int | None = None,
+    max_in_flight_bytes: int = _DEFAULT_MAX_IN_FLIGHT_BYTES,
+    budget: _ByteBudget | None = None,
 ) -> None:
     """Write tensor data to an external file according to information stored in ExternalDataInfo objects.
 
@@ -443,41 +446,129 @@ def _write_external_data(
         file_path: Location to which external data is to be stored.
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes.
+        max_workers: Number of threads used to materialize and write tensors. ``None``
+            or ``1`` writes serially.
+        max_in_flight_bytes: Upper bound on materialized tensor bytes held in memory
+            when writing concurrently. Ignored when ``budget`` is given.
+        budget: An existing byte budget to share across concurrent shard writes so that
+            peak memory does not scale with the number of shards.
     """
     tensors_count = len(tensors)
     assert tensors_count == len(external_data_infos), (
         "Number of tensors and external data infos should match"
     )
+
+    filename = os.path.basename(file_path)
+
+    def _invoke_callback(index: int, tensor: _protocols.TensorProtocol, offset: int) -> None:
+        if callback is None:
+            return
+        callback(
+            tensor,
+            CallbackInfo(
+                total=tensors_count,
+                index=index,
+                offset=offset,
+                filename=filename,
+            ),
+        )
+
+    if max_workers is not None and max_workers > 1 and tensors_count > 1:
+        _write_external_data_parallel(
+            tensors,
+            external_data_infos,
+            file_path,
+            _invoke_callback,
+            max_workers=max_workers,
+            max_in_flight_bytes=max_in_flight_bytes,
+            budget=budget,
+        )
+        return
+
     with open(file_path, "wb") as data_file:
         for i, (tensor, tensor_info) in enumerate(
             zip(tensors, external_data_infos, strict=True)
         ):
-            if callback is not None:
-                callback(
-                    tensor,
-                    CallbackInfo(
-                        total=tensors_count,
-                        index=i,
-                        offset=tensor_info.offset,
-                        filename=os.path.basename(file_path),
-                    ),
-                )
-            current_offset = tensor_info.offset
             assert tensor is not None
-            # Pad file to required offset if needed
+            _invoke_callback(i, tensor, tensor_info.offset)
+            # Pad the file up to the target offset if needed
             file_size = data_file.tell()
-            if current_offset > file_size:
-                data_file.write(b"\0" * (current_offset - file_size))
+            if tensor_info.offset > file_size:
+                data_file.write(b"\0" * (tensor_info.offset - file_size))
+            _write_tensor_at(tensor, data_file, tensor_info.offset)
 
-            if hasattr(tensor, "tofile"):
-                # Some existing implementation of TensorProtocol
-                # may not have tofile() as it was introduced in v0.1.11
-                tensor.tofile(data_file)
-            else:
-                raw_data = tensor.tobytes()
-                if isinstance(tensor, _core.ExternalTensor):
-                    tensor.release()
-                data_file.write(raw_data)
+
+def _write_external_data_parallel(
+    tensors: Sequence[_protocols.TensorProtocol],
+    external_data_infos: Sequence[_ExternalDataInfo],
+    file_path: str | os.PathLike,
+    invoke_callback: Callable[[int, _protocols.TensorProtocol, int], None],
+    *,
+    max_workers: int,
+    max_in_flight_bytes: int,
+    budget: _ByteBudget | None = None,
+) -> None:
+    """Write tensors concurrently to preassigned offsets in ``file_path``.
+
+    Every tensor's byte range is known up front, so writes have no ordering
+    dependency on one another. The file is preallocated to its final size and
+    each worker opens its own file object, giving every thread an independent
+    file position and removing the need for a write lock. Both ``write()`` and
+    the numpy/torch work behind materialization release the GIL, so this
+    overlaps computation with I/O *and* parallelizes each of them.
+
+    Peak memory is bounded by a byte budget rather than a queue length: a worker
+    reserves a tensor's size before materializing it and releases the
+    reservation once the bytes have reached the file.
+
+    The bytes written are identical to the serial path.
+    """
+    total_size = max(
+        (info.offset + info.length for info in external_data_infos),
+        default=0,
+    )
+    # Preallocate so that every worker can seek to its own offset. Holes read
+    # back as zeros, matching the explicit zero padding written serially.
+    with open(file_path, "wb") as data_file:
+        data_file.truncate(total_size)
+
+    budget = budget if budget is not None else _ByteBudget(max_in_flight_bytes)
+    callback_lock = threading.Lock()
+    thread_local = threading.local()
+    files: list = []
+    files_lock = threading.Lock()
+
+    def _thread_file():
+        data_file = getattr(thread_local, "data_file", None)
+        if data_file is None:
+            # Closed in the caller's finally block, after all workers are done.
+            data_file = open(file_path, "r+b")  # ruff: ignore[open-file-with-context-handler]
+            thread_local.data_file = data_file
+            with files_lock:
+                files.append(data_file)
+        return data_file
+
+    def _write_one(index: int) -> None:
+        tensor = tensors[index]
+        info = external_data_infos[index]
+        assert tensor is not None
+        with callback_lock:
+            invoke_callback(index, tensor, info.offset)
+        reserved = budget.acquire(info.length)
+        try:
+            _write_tensor_at(tensor, _thread_file(), info.offset)
+        finally:
+            budget.release(reserved)
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_write_one, i) for i in range(len(tensors))]
+            # Surface the first failure while letting the pool unwind cleanly.
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
+    finally:
+        for data_file in files:
+            data_file.close()
 
 
 def _create_external_tensor(
@@ -527,53 +618,73 @@ def convert_tensors_to_external(
     base_dir: str | os.PathLike,
     relative_path: str | os.PathLike,
     callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
+    max_workers: int | None = None,
+    max_in_flight_bytes: int = _DEFAULT_MAX_IN_FLIGHT_BYTES,
+    alignment: int | None = None,
+    align_threshold: int = _DEFAULT_ALIGN_THRESHOLD,
+    _budget: _ByteBudget | None = None,
 ) -> list[_core.ExternalTensor]:
     """Convert a sequence of any TensorProtocol tensors to external tensors.
 
     Existing external tensors are loaded to memory if they are referring to the
     same file path as the destination path.
 
+    Tensors are written in the order they are given, packed densely unless
+    ``alignment`` is set. Preserving the input order matters: initializers are
+    declared in topological order by every mainstream exporter, so the weights of
+    one layer stay adjacent on disk. Runtimes memory-map each tensor separately
+    and do not prefetch, so page faults are served in execution order and
+    adjacency turns that into a sequential read.
+
     Args:
         tensors: Tensors to be converted to external tensors. They can be external tensors themselves.
         base_dir: Path of base directory.
         relative_path: Path to which external data is to be stored, relative to the ONNX file.
         callback: A callback function that is called for each tensor that is saved to external data
-            for debugging or logging purposes.
+            for debugging or logging purposes. When ``max_workers`` enables concurrency the
+            callback is serialized with a lock but is no longer invoked in index order.
+        max_workers: Number of threads used to materialize and write tensors. ``None``
+            or ``1`` writes serially.
+        max_in_flight_bytes: Upper bound on materialized tensor bytes held in memory
+            when writing concurrently.
+        alignment: Alignment to apply to the offsets of large tensors, in bytes.
+            ``None`` (the default) packs tensors densely with no padding. When set,
+            offsets are aligned to ``max(4096, alignment)``; 65536 matches the
+            Windows allocation granularity used for memory mapping.
+        align_threshold: Only tensors strictly larger than this many bytes are
+            aligned. Ignored when ``alignment`` is ``None``.
 
     Returns:
         A list of external tensors derived from a list of input tensors. The order
-        should match the input tensor order.
+        matches the input tensor order.
     """
     path = os.path.join(base_dir, relative_path)
     tensors = _materialize_external_tensors_for_destination_paths(tensors, [path])
 
-    external_data_infos: list[_ExternalDataInfo] = []
-    # Sort all tensors based on tensor sizes, in order to avoid unnecessary alignment.
-    # All the smaller tensors are written earlier and alignment is performed for the larger tensors.
-    sorted_indices = sorted(range(len(tensors)), key=lambda i: tensors[i].nbytes)
-    sorted_tensors = [tensors[i] for i in sorted_indices]
-
     # Compute external data information for each tensor and write to disk
+    external_data_infos: list[_ExternalDataInfo] = []
     current_offset = 0
-    for tensor in sorted_tensors:
-        external_info = _compute_external_data_info(tensor, current_offset)
+    for tensor in tensors:
+        external_info = _compute_external_data_info(
+            tensor, current_offset, alignment, align_threshold
+        )
         external_data_infos.append(external_info)
         current_offset = external_info.offset + external_info.length
-    _write_external_data(sorted_tensors, external_data_infos, path, callback=callback)
+    _write_external_data(
+        tensors,
+        external_data_infos,
+        path,
+        callback=callback,
+        max_workers=max_workers,
+        max_in_flight_bytes=max_in_flight_bytes,
+        budget=_budget,
+    )
 
     # Create external tensor objects
-    external_tensors: list[_core.ExternalTensor] = [
+    return [
         _create_external_tensor(tensor, external_info, base_dir, relative_path)
-        for tensor, external_info in zip(sorted_tensors, external_data_infos, strict=True)
+        for tensor, external_info in zip(tensors, external_data_infos, strict=True)
     ]
-
-    # Sort external_tensors based on original key order. So that it can match the input tensor order
-    external_tensors = [
-        external_tensors[i]
-        for i in sorted(range(len(external_tensors)), key=lambda i: sorted_indices[i])
-    ]
-
-    return external_tensors
 
 
 def load_to_model(model: _core.Model) -> _core.Model:
@@ -612,6 +723,10 @@ def unload_from_model(
     size_threshold_bytes: int = 0,
     max_shard_size_bytes: int | None = None,
     callback: Callable[[_protocols.TensorProtocol, CallbackInfo], None] | None = None,
+    max_workers: int | None = None,
+    max_in_flight_bytes: int = _DEFAULT_MAX_IN_FLIGHT_BYTES,
+    alignment: int | None = None,
+    align_threshold: int = _DEFAULT_ALIGN_THRESHOLD,
 ) -> _core.Model:
     """Convert all initializers equal or above size_threshold_bytes to external tensors in-place and save data to one or more data files.
 
@@ -645,7 +760,24 @@ def unload_from_model(
             in its own oversized shard.
         callback: A callback function that is called for each tensor that is saved to external data
             for debugging or logging purposes. Under sharding the callback index reflects
-            each shard's size-sorted write order while remaining globally contiguous.
+            each shard's write order while remaining globally contiguous. When
+            ``max_workers`` enables concurrency the callback is serialized with a lock
+            but is no longer invoked in index order.
+        max_workers: Number of threads used to materialize and write tensors. ``None``
+            (the default) or ``1`` writes serially, preserving the previous behavior.
+            Values above 1 overlap tensor materialization (dtype conversion, lazy tensor
+            evaluation) with disk writes and parallelize both. Shards are also written
+            concurrently.
+        max_in_flight_bytes: Upper bound on materialized tensor bytes held in memory
+            when writing concurrently. Peak memory is bounded by this value plus the
+            size of the largest single tensor. Shared across shards so that peak memory
+            does not grow with the shard count.
+        alignment: Alignment to apply to the offsets of large tensors, in bytes.
+            ``None`` (the default) packs tensors densely with no padding. When set,
+            offsets are aligned to ``max(4096, alignment)``; 65536 matches the
+            Windows allocation granularity used for memory mapping.
+        align_threshold: Only tensors strictly larger than this many bytes are
+            aligned. Ignored when ``alignment`` is ``None``.
 
     Returns:
         An ir.Model with all initializer data equal or above ``size_threshold_bytes``
@@ -711,6 +843,10 @@ def unload_from_model(
             base_dir=base_dir,
             relative_path=relative_path,
             callback=callback,
+            max_workers=max_workers,
+            max_in_flight_bytes=max_in_flight_bytes,
+            alignment=alignment,
+            align_threshold=align_threshold,
         )
     else:
         # Sharding: distribute tensors across multiple numbered shard files
@@ -718,7 +854,9 @@ def unload_from_model(
             v.const_value  # type: ignore[misc]
             for v in initializers_to_become_external
         ]
-        tensor_shards = _shard_tensors(tensors_to_externalize, max_shard_size_bytes)
+        tensor_shards = _shard_tensors(
+            tensors_to_externalize, max_shard_size_bytes, alignment, align_threshold
+        )
         total_shards = len(tensor_shards)
         total_tensors = len(tensors_to_externalize)
         shard_relative_paths = [
@@ -739,6 +877,7 @@ def unload_from_model(
         _check_no_existing_shard_files(destination_paths)
 
         external_tensors = []
+        shard_jobs: list[tuple[Sequence[_protocols.TensorProtocol], str, Callable | None]] = []
         global_index = 0
 
         for shard_relative_path, shard_tensor_count in zip(
@@ -755,16 +894,60 @@ def unload_from_model(
             ) = None
             if callback is not None:
                 shard_callback = _make_shard_callback(callback, total_tensors, global_index)
-
-            shard_external_tensors = convert_tensors_to_external(
-                shard_tensors,
-                base_dir=base_dir,
-                relative_path=shard_relative_path,
-                callback=shard_callback,
-            )
-
-            external_tensors.extend(shard_external_tensors)
+            shard_jobs.append((shard_tensors, shard_relative_path, shard_callback))
             global_index += shard_tensor_count
+
+        if max_workers is not None and max_workers > 1 and len(shard_jobs) > 1:
+            # Shards are distinct files with no ordering dependency, so they are
+            # written concurrently. They share one byte budget so that peak memory
+            # does not grow with the number of shards.
+            shared_budget = _ByteBudget(max_in_flight_bytes)
+            shard_lock = threading.Lock()
+
+            def _locked_callback(
+                inner: Callable[[_protocols.TensorProtocol, CallbackInfo], None],
+            ) -> Callable[[_protocols.TensorProtocol, CallbackInfo], None]:
+                def _wrapped(tensor: _protocols.TensorProtocol, info: CallbackInfo) -> None:
+                    with shard_lock:
+                        inner(tensor, info)
+
+                return _wrapped
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+                shard_futures = [
+                    executor.submit(
+                        convert_tensors_to_external,
+                        job_tensors,
+                        base_dir=base_dir,
+                        relative_path=job_path,
+                        callback=(
+                            _locked_callback(job_callback)
+                            if job_callback is not None
+                            else None
+                        ),
+                        max_workers=max_workers,
+                        alignment=alignment,
+                        align_threshold=align_threshold,
+                        _budget=shared_budget,
+                    )
+                    for job_tensors, job_path, job_callback in shard_jobs
+                ]
+                for shard_future in shard_futures:
+                    external_tensors.extend(shard_future.result())
+        else:
+            for job_tensors, job_path, job_callback in shard_jobs:
+                external_tensors.extend(
+                    convert_tensors_to_external(
+                        job_tensors,
+                        base_dir=base_dir,
+                        relative_path=job_path,
+                        callback=job_callback,
+                        max_workers=max_workers,
+                        max_in_flight_bytes=max_in_flight_bytes,
+                        alignment=alignment,
+                        align_threshold=align_threshold,
+                    )
+                )
 
     # Replace the initializer values with external tensors and save the model
     for value, external_tensor in zip(

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -909,6 +909,13 @@ def unload_from_model(
             # Shards are distinct files with no ordering dependency, so they are
             # written concurrently. They share one byte budget so that peak memory
             # does not grow with the number of shards.
+            #
+            # Split ``max_workers`` across the two levels instead of using it at
+            # both: nesting a pool of that size inside each of that many shard
+            # threads would spawn up to ``max_workers ** 2`` threads, breaking
+            # the contract that ``max_workers`` bounds the thread count.
+            shard_workers = min(max_workers, len(shard_jobs))
+            workers_per_shard = max(1, max_workers // shard_workers)
             shared_budget = _ByteBudget(max_in_flight_bytes)
             shard_lock = threading.Lock()
 
@@ -921,7 +928,7 @@ def unload_from_model(
 
                 return _wrapped
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=shard_workers) as executor:
                 shard_futures = [
                     executor.submit(
                         convert_tensors_to_external,
@@ -933,7 +940,7 @@ def unload_from_model(
                             if job_callback is not None
                             else None
                         ),
-                        max_workers=max_workers,
+                        max_workers=workers_per_shard,
                         alignment=alignment,
                         align_threshold=align_threshold,
                         _budget=shared_budget,

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -173,7 +173,16 @@ def _get_shard_filename(base_name: str, shard_idx: int, total_shards: int) -> st
         return base_name
 
     dir_name, filename = os.path.split(base_name)
-    name, ext = os.path.splitext(filename)
+    # ``.onnx.data`` is a conventional compound suffix. Treating only
+    # ``.data`` as the extension would produce
+    # ``model.onnx-00001-of-00003.data``; keep the compound suffix intact so
+    # the shard marker belongs to the model stem instead.
+    compound_suffix = ".onnx.data"
+    if filename.endswith(compound_suffix):
+        name = filename[: -len(compound_suffix)]
+        ext = compound_suffix
+    else:
+        name, ext = os.path.splitext(filename)
 
     # Always use 5 digits to follow transformers convention
     shard_filename = f"{name}-{shard_idx:05d}-of-{total_shards:05d}{ext}"

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -32,9 +32,6 @@ from onnx_ir._polyfill import zip
 # Default alignment threshold used when alignment is enabled: only tensors larger
 # than this get their offset aligned, so small initializers don't waste file space.
 _DEFAULT_ALIGN_THRESHOLD = 1048576  # 1MB
-# Default allocation granularity for mmap() support. Typically 64KB on Windows
-# and 4KB elsewhere; 64KB is the safe cross-platform choice.
-_DEFAULT_ALLOCATION_GRANULARITY = 65536  # 64KB
 # Default upper bound on materialized tensor bytes held in memory while writing
 # external data concurrently. Peak memory is this plus the largest single tensor.
 _DEFAULT_MAX_IN_FLIGHT_BYTES = 1 << 30  # 1GB
@@ -425,8 +422,6 @@ def _write_tensor_at(
         tensor.tofile(file)
     else:
         file.write(tensor.tobytes())
-    if isinstance(tensor, _core.ExternalTensor):
-        tensor.release()
 
 
 def _write_tensor_with_budget_at(
@@ -501,6 +496,10 @@ def _write_external_data(
             max_in_flight_bytes=max_in_flight_bytes,
         )
         writer.write()
+        # Windows cannot atomically replace a file while one of its mmap handles
+        # is open. Other ExternalTensors are left untouched.
+        for tensor in overwritten_tensors:
+            tensor.release()
         if os.path.exists(destination_path):
             shutil.copymode(destination_path, temporary_path)
         os.replace(temporary_path, destination_path)

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -546,6 +546,7 @@ def _write_external_data(
             try:
                 _write_tensor_at(tensor, data_file, tensor_info.offset)
             finally:
+                # Release the budget if writing fails; the exception still propagates.
                 budget.release(reserved)
 
 
@@ -609,6 +610,7 @@ def _write_external_data_parallel(
         try:
             _write_tensor_at(tensor, _thread_file(), info.offset)
         finally:
+            # Release the budget if writing fails; the exception still propagates.
             budget.release(reserved)
 
     try:

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -527,6 +527,8 @@ def _write_external_data(
         return
 
     with open(file_path, "wb") as data_file:
+        # Seeking past EOF creates a file hole that reads back as zeros, so
+        # aligned offsets need no explicit padding allocation or write.
         for i, (tensor, tensor_info) in enumerate(
             zip(tensors, external_data_infos, strict=True)
         ):

--- a/src/onnx_ir/external_data.py
+++ b/src/onnx_ir/external_data.py
@@ -442,6 +442,13 @@ class _ByteBudget:
             self._condition.notify_all()
 
 
+def _reservation_bytes(tensor: _protocols.TensorProtocol, tensor_length: int) -> int:
+    """Return the maximum userspace memory needed while writing a tensor."""
+    if isinstance(tensor, _core.ExternalTensor):
+        return min(tensor_length, _core._EXTERNAL_TENSOR_COPY_CHUNK_SIZE)
+    return tensor_length
+
+
 def _write_tensor_at(
     tensor: _protocols.TensorProtocol,
     file,
@@ -533,7 +540,7 @@ def _write_external_data(
             # A shard may use a serial writer while other shards are written
             # concurrently. Honor their shared budget here too; otherwise one
             # tensor per shard can be materialized at once with no byte bound.
-            reserved = budget.acquire(tensor_info.length)
+            reserved = budget.acquire(_reservation_bytes(tensor, tensor_info.length))
             try:
                 _write_tensor_at(tensor, data_file, tensor_info.offset)
             finally:
@@ -596,7 +603,7 @@ def _write_external_data_parallel(
         assert tensor is not None
         with callback_lock:
             invoke_callback(index, tensor, info.offset)
-        reserved = budget.acquire(info.length)
+        reserved = budget.acquire(_reservation_bytes(tensor, info.length))
         try:
             _write_tensor_at(tensor, _thread_file(), info.offset)
         finally:

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -4,6 +4,7 @@ import os
 import sys
 import tempfile
 import threading
+import time
 import typing
 import unittest
 
@@ -1009,6 +1010,49 @@ class ParallelWriteTest(unittest.TestCase):
         amount = budget.acquire(10_000)
         self.assertEqual(amount, 100)
         budget.release(amount)
+
+    def test_sharded_save_respects_the_worker_limit(self):
+        # Shards are written concurrently and each shard writes its tensors
+        # concurrently. Using max_workers at both levels would spawn up to
+        # max_workers ** 2 threads, so the budget must be split, not squared.
+        rng = np.random.default_rng(3)
+        graph = ir.Graph(inputs=[], outputs=[], nodes=[], initializers=[], name="g")
+        for i in range(40):
+            tensor = ir.Tensor(
+                rng.integers(0, 255, size=200_000, dtype=np.uint8), name=f"w{i}"
+            )
+            graph.register_initializer(ir.Value(name=f"w{i}", const_value=tensor))
+        model = ir.Model(graph, ir_version=10)
+
+        max_workers = 4
+        peak = 0
+        stop = threading.Event()
+
+        def monitor():
+            nonlocal peak
+            while not stop.is_set():
+                peak = max(peak, threading.active_count())
+                time.sleep(0.001)
+
+        watcher = threading.Thread(target=monitor)
+        watcher.start()
+        # Sample the baseline with the watcher already running so it is not
+        # mistaken for a worker.
+        time.sleep(0.01)
+        baseline = threading.active_count()
+        try:
+            external_data.unload_from_model(
+                model,
+                self.base_path,
+                "model.data",
+                max_shard_size_bytes=1_000_000,
+                max_workers=max_workers,
+            )
+        finally:
+            stop.set()
+            watcher.join()
+
+        self.assertLessEqual(peak - baseline, max_workers)
 
     def test_parallel_sharded_save_matches_serial(self):
         def build_model():

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -1027,11 +1027,29 @@ class ParallelWriteTest(unittest.TestCase):
         thread.join()
 
     def test_byte_budget_admits_tensor_larger_than_capacity(self):
-        # An oversized tensor must not deadlock; it is admitted on its own.
+        # One oversized tensor may coexist with regular reservations, but a
+        # second oversized tensor waits so peak memory remains
+        # capacity + largest tensor.
         budget = external_data._ByteBudget(100)
-        amount = budget.acquire(10_000)
-        self.assertEqual(amount, 100)
-        budget.release(amount)
+        oversized = budget.acquire(10_000)
+        self.assertEqual(oversized, -1)
+        regular = budget.acquire(100)
+        self.assertEqual(regular, 100)
+
+        second_acquired = threading.Event()
+
+        def acquire_second_oversized():
+            reservation = budget.acquire(20_000)
+            second_acquired.set()
+            budget.release(reservation)
+
+        thread = threading.Thread(target=acquire_second_oversized)
+        thread.start()
+        self.assertFalse(second_acquired.wait(timeout=0.2))
+        budget.release(oversized)
+        self.assertTrue(second_acquired.wait(timeout=5))
+        budget.release(regular)
+        thread.join()
 
     def test_serial_shard_writer_honors_shared_byte_budget(self):
         class TrackingBudget:

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -1018,6 +1018,40 @@ class ParallelWriteTest(unittest.TestCase):
         self.assertEqual(amount, 100)
         budget.release(amount)
 
+    def test_serial_shard_writer_honors_shared_byte_budget(self):
+        class TrackingBudget:
+            def __init__(self):
+                self.acquired = []
+                self.released = []
+
+            def acquire(self, nbytes):
+                self.acquired.append(nbytes)
+                return nbytes
+
+            def release(self, nbytes):
+                self.released.append(nbytes)
+
+        tensors = self._make_tensors(count=3)
+        infos = []
+        offset = 0
+        for tensor in tensors:
+            info = external_data._compute_external_data_info(tensor, offset)
+            infos.append(info)
+            offset += info.length
+        budget = TrackingBudget()
+
+        external_data._write_external_data(
+            tensors,
+            infos,
+            os.path.join(self.base_path, "model.data"),
+            max_workers=1,
+            budget=budget,  # type: ignore[arg-type]
+        )
+
+        expected = [info.length for info in infos]
+        self.assertEqual(budget.acquired, expected)
+        self.assertEqual(budget.released, expected)
+
     def test_sharded_save_respects_the_worker_limit(self):
         # Shards are written concurrently and each shard writes its tensors
         # concurrently. Applying max_workers at both levels would spawn up to

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -1051,6 +1051,23 @@ class ParallelWriteTest(unittest.TestCase):
         budget.release(regular)
         thread.join()
 
+    def test_external_tensor_reserves_only_copy_buffer(self):
+        length = 10 * 1024 * 1024
+        tensor = ir.ExternalTensor(
+            "source.data",
+            offset=0,
+            length=length,
+            dtype=ir.DataType.UINT8,
+            shape=ir.Shape([length]),
+            base_dir=self.base_path,
+            name="external",
+        )
+
+        self.assertEqual(
+            external_data._reservation_bytes(tensor, length),
+            1024 * 1024,
+        )
+
     def test_serial_shard_writer_honors_shared_byte_budget(self):
         class TrackingBudget:
             def __init__(self):

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -546,13 +546,21 @@ class ShardFilenameTest(unittest.TestCase):
             "model-00003-of-00003.data",
         )
 
-    def test_onnx_data_compound_suffix_is_preserved(self):
-        self.assertEqual(
-            external_data._get_shard_filename("model.onnx.data", 2, 9),
-            "model-00002-of-00009.onnx.data",
-        )
+    def test_compound_suffixes_are_preserved(self):
+        cases = {
+            "model.onnx.data": "model-00002-of-00009.onnx.data",
+            "model.weights.bin": "model-00002-of-00009.weights.bin",
+            "archive.tar.gz": "archive-00002-of-00009.tar.gz",
+            ".weights.data": ".weights-00002-of-00009.data",
+        }
+        for filename, expected in cases.items():
+            with self.subTest(filename=filename):
+                self.assertEqual(
+                    external_data._get_shard_filename(filename, 2, 9),
+                    expected,
+                )
 
-    def test_onnx_data_compound_suffix_with_directory(self):
+    def test_compound_suffix_with_directory(self):
         self.assertEqual(
             external_data._get_shard_filename("weights.dir/model.onnx.data", 3, 10),
             os.path.join("weights.dir", "model-00003-of-00010.onnx.data"),

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -403,6 +403,7 @@ class OffloadExternalTensorTest(unittest.TestCase):
             any(name.startswith(temporary_prefix) for name in os.listdir(self.base_path))
         )
 
+    @unittest.skipIf(sys.platform == "win32", "POSIX mode bits are unavailable on Windows")
     def test_atomic_replace_preserves_existing_file_mode(self):
         destination = os.path.join(self.base_path, self.external_data_name)
         with open(destination, "wb") as data_file:
@@ -467,6 +468,23 @@ class OffloadExternalTensorTest(unittest.TestCase):
         self.assertEqual(external_tensor3.numpy().tobytes(), self.data_ext1_1.tobytes())
         self.assertEqual(external_tensor4.numpy().tobytes(), self.data_ext1_2.tobytes())
         self.assertEqual(external_tensor5.numpy().tobytes(), self.data_ext2_1.tobytes())
+
+    def test_different_destination_does_not_release_source_external_tensor(self):
+        source_tensor = self.model_with_external_data_diff_path.graph.initializers[
+            "tensor_ext1_1"
+        ].const_value
+        source_array = source_tensor.numpy()
+
+        external_data.unload_from_model(
+            self.model_with_external_data_diff_path,
+            self.base_path,
+            self.external_data_name,
+        )
+
+        self.assertTrue(source_tensor.valid())
+        np.testing.assert_array_equal(source_array, self.data_ext1_1)
+        del source_array
+        source_tensor.release()
 
     def test_custom_tensor_in_initializers(self):
         model_with_external_data = external_data.unload_from_model(

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -825,6 +825,9 @@ class ShardedExternalDataTest(unittest.TestCase):
         self.assertTrue(all(i.total == 3 for i in infos))
         # indices should be 0, 1, 2 across all shards
         self.assertEqual(sorted(i.index for i in infos), [0, 1, 2])
+        # Each tensor is in its own shard, so per-shard progress is 0 of 1.
+        self.assertTrue(all(i.shard_total == 1 for i in infos))
+        self.assertTrue(all(i.shard_index == 0 for i in infos))
 
     def test_cleanup_leaves_unowned_zero_indexed_shard_files_alone(self):
         # Shard indices are 1-indexed and the 0-indexed file *is* invalid, but

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -1107,6 +1107,50 @@ class ParallelWriteTest(unittest.TestCase):
                 tensors, self.base_path, "model.data", max_workers=4
             )
 
+    def test_shared_lazy_tensor_is_evaluated_once_across_shards(self):
+        evaluation_count = 0
+        count_lock = threading.Lock()
+
+        def evaluate():
+            nonlocal evaluation_count
+            with count_lock:
+                evaluation_count += 1
+            # Make concurrent cache misses deterministic without the write lock.
+            time.sleep(0.1)
+            return ir.tensor([1], dtype=ir.DataType.INT64)
+
+        shared_tensor = ir.LazyTensor(
+            evaluate,
+            dtype=ir.DataType.INT64,
+            shape=ir.Shape([1]),
+            cache=True,
+            name="shared",
+        )
+        model = ir.Model(
+            ir.Graph(
+                [],
+                [],
+                nodes=[],
+                initializers=[
+                    ir.Value(name="first", const_value=shared_tensor),
+                    ir.Value(name="second", const_value=shared_tensor),
+                ],
+                name="graph",
+            ),
+            ir_version=10,
+        )
+
+        external_data.unload_from_model(
+            model,
+            self.base_path,
+            "model.data",
+            size_threshold_bytes=0,
+            max_shard_size_bytes=shared_tensor.nbytes,
+            max_workers=2,
+        )
+
+        self.assertEqual(evaluation_count, 1)
+
     def test_byte_budget_bounds_in_flight_bytes(self):
         budget = external_data._ByteBudget(1000)
         first = budget.acquire(600)

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -546,6 +546,18 @@ class ShardFilenameTest(unittest.TestCase):
             "model-00003-of-00003.data",
         )
 
+    def test_onnx_data_compound_suffix_is_preserved(self):
+        self.assertEqual(
+            external_data._get_shard_filename("model.onnx.data", 2, 9),
+            "model-00002-of-00009.onnx.data",
+        )
+
+    def test_onnx_data_compound_suffix_with_directory(self):
+        self.assertEqual(
+            external_data._get_shard_filename("weights.dir/model.onnx.data", 3, 10),
+            os.path.join("weights.dir", "model-00003-of-00010.onnx.data"),
+        )
+
     def test_filename_without_extension(self):
         self.assertEqual(
             external_data._get_shard_filename("model", 2, 5),

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -16,6 +16,13 @@ import onnx_ir as ir
 from onnx_ir import external_data
 
 
+def _sample_thread_count(stop: threading.Event, samples: list[int]) -> None:
+    """Poll the live thread count until ``stop`` is set."""
+    while not stop.is_set():
+        samples.append(threading.active_count())
+        time.sleep(0.0005)
+
+
 class ExternalDataTest(unittest.TestCase):
     def test_set_base_dir_sets_base_dir_for_all_external_tensors(self):
         attr_tensor = onnx.helper.make_tensor(
@@ -1013,46 +1020,51 @@ class ParallelWriteTest(unittest.TestCase):
 
     def test_sharded_save_respects_the_worker_limit(self):
         # Shards are written concurrently and each shard writes its tensors
-        # concurrently. Using max_workers at both levels would spawn up to
-        # max_workers ** 2 threads, so the budget must be split, not squared.
-        rng = np.random.default_rng(3)
-        graph = ir.Graph(inputs=[], outputs=[], nodes=[], initializers=[], name="g")
-        for i in range(40):
-            tensor = ir.Tensor(
-                rng.integers(0, 255, size=200_000, dtype=np.uint8), name=f"w{i}"
-            )
-            graph.register_initializer(ir.Value(name=f"w{i}", const_value=tensor))
-        model = ir.Model(graph, ir_version=10)
+        # concurrently. Applying max_workers at both levels would spawn up to
+        # max_workers ** 2 threads, so the budget is split across the two
+        # levels. Shard counts are chosen so that each shard holds several
+        # tensors and the inner pools are genuinely live; with one tensor per
+        # shard the inner pool is skipped and the nesting is never exercised.
+        tensor_count = 64
+        tensor_size = 200_000
+        total_size = tensor_count * tensor_size
 
-        max_workers = 4
-        peak = 0
-        stop = threading.Event()
+        def build_model():
+            rng = np.random.default_rng(3)
+            graph = ir.Graph(inputs=[], outputs=[], nodes=[], initializers=[], name="g")
+            for i in range(tensor_count):
+                tensor = ir.Tensor(
+                    rng.integers(0, 255, size=tensor_size, dtype=np.uint8), name=f"w{i}"
+                )
+                graph.register_initializer(ir.Value(name=f"w{i}", const_value=tensor))
+            return ir.Model(graph, ir_version=10)
 
-        def monitor():
-            nonlocal peak
-            while not stop.is_set():
-                peak = max(peak, threading.active_count())
-                time.sleep(0.001)
+        for shard_count, max_workers in ((2, 8), (3, 8), (4, 8), (2, 4), (4, 16)):
+            with self.subTest(shard_count=shard_count, max_workers=max_workers):
+                model = build_model()
+                directory = tempfile.mkdtemp(dir=self.base_path)
+                stop = threading.Event()
+                samples: list[int] = []
 
-        watcher = threading.Thread(target=monitor)
-        watcher.start()
-        # Sample the baseline with the watcher already running so it is not
-        # mistaken for a worker.
-        time.sleep(0.01)
-        baseline = threading.active_count()
-        try:
-            external_data.unload_from_model(
-                model,
-                self.base_path,
-                "model.data",
-                max_shard_size_bytes=1_000_000,
-                max_workers=max_workers,
-            )
-        finally:
-            stop.set()
-            watcher.join()
+                watcher = threading.Thread(target=_sample_thread_count, args=(stop, samples))
+                watcher.start()
+                # Sample the baseline with the watcher already running so it is
+                # not mistaken for a worker.
+                time.sleep(0.01)
+                baseline = threading.active_count()
+                try:
+                    external_data.unload_from_model(
+                        model,
+                        directory,
+                        "model.data",
+                        max_shard_size_bytes=total_size // shard_count,
+                        max_workers=max_workers,
+                    )
+                finally:
+                    stop.set()
+                    watcher.join()
 
-        self.assertLessEqual(peak - baseline, max_workers)
+                self.assertLessEqual(max(samples, default=baseline) - baseline, max_workers)
 
     def test_parallel_sharded_save_matches_serial(self):
         def build_model():

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -7,6 +7,7 @@ import threading
 import time
 import typing
 import unittest
+import unittest.mock
 
 import numpy as np
 import onnx
@@ -346,11 +347,22 @@ class OffloadExternalTensorTest(unittest.TestCase):
         self.assertEqual(external_tensor2.numpy().tobytes(), self.data_float16.tobytes())
 
     def test_same_path_external_data(self):
-        model_with_external_data = external_data.unload_from_model(
-            self.model_with_external_data_same_path,
-            self.base_path,
-            self.external_data_name,
-        )
+        original_external_tensor = self.model_with_external_data_same_path.graph.initializers[
+            "tensor_same_file"
+        ].const_value
+        with unittest.mock.patch.object(
+            external_data,
+            "_external_tensor_to_memory_tensor",
+            side_effect=AssertionError(
+                "same-path writes should stream through a temporary file"
+            ),
+        ):
+            model_with_external_data = external_data.unload_from_model(
+                self.model_with_external_data_same_path,
+                self.base_path,
+                self.external_data_name,
+            )
+        self.assertFalse(original_external_tensor.valid())
         external_tensor = model_with_external_data.graph.initializers["tensor1"].const_value
         external_tensor2 = model_with_external_data.graph.initializers["tensor2"].const_value
         external_tensor3 = model_with_external_data.graph.initializers[
@@ -364,6 +376,67 @@ class OffloadExternalTensorTest(unittest.TestCase):
         self.assertEqual(external_tensor.numpy().tobytes(), self.data.tobytes())
         self.assertEqual(external_tensor2.numpy().tobytes(), self.data_float16.tobytes())
         self.assertEqual(external_tensor3.numpy().tobytes(), self.data_other.tobytes())
+
+    def test_write_failure_preserves_existing_external_data(self):
+        class ExplodingTensor(ir.Tensor):
+            def tofile(self, file):
+                file.write(b"partial")
+                raise RuntimeError("boom")
+
+        destination = os.path.join(self.base_path, self.external_data_name)
+        original_data = b"existing external data"
+        with open(destination, "wb") as data_file:
+            data_file.write(original_data)
+        tensor = ExplodingTensor(np.zeros(4, dtype=np.uint8), name="exploding")
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            external_data.convert_tensors_to_external(
+                [tensor],
+                self.base_path,
+                self.external_data_name,
+            )
+
+        with open(destination, "rb") as data_file:
+            self.assertEqual(data_file.read(), original_data)
+        temporary_prefix = f".{self.external_data_name}."
+        self.assertFalse(
+            any(name.startswith(temporary_prefix) for name in os.listdir(self.base_path))
+        )
+
+    def test_atomic_replace_preserves_existing_file_mode(self):
+        destination = os.path.join(self.base_path, self.external_data_name)
+        with open(destination, "wb") as data_file:
+            data_file.write(b"old")
+        os.chmod(destination, 0o640)
+
+        external_data.convert_tensors_to_external(
+            [ir.Tensor(np.zeros(4, dtype=np.uint8), name="tensor")],
+            self.base_path,
+            self.external_data_name,
+        )
+
+        self.assertEqual(os.stat(destination).st_mode & 0o777, 0o640)
+
+    def test_atomic_replace_preserves_destination_symlink(self):
+        target_name = "target.data"
+        target = os.path.join(self.base_path, target_name)
+        link = os.path.join(self.base_path, self.external_data_name)
+        with open(target, "wb") as data_file:
+            data_file.write(b"old")
+        try:
+            os.symlink(target_name, link)
+        except OSError as error:
+            self.skipTest(f"Cannot create symlink on this platform: {error}")
+
+        external_data.convert_tensors_to_external(
+            [ir.Tensor(np.arange(4, dtype=np.uint8), name="tensor")],
+            self.base_path,
+            self.external_data_name,
+        )
+
+        self.assertTrue(os.path.islink(link))
+        with open(target, "rb") as data_file:
+            self.assertEqual(data_file.read(), bytes(range(4)))
 
     def test_external_data_diff_paths(self):
         model_with_external_data = external_data.unload_from_model(

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import tempfile
+import threading
 import typing
 import unittest
 
@@ -60,55 +61,39 @@ class ExternalDataTest(unittest.TestCase):
         self.assertEqual(attr_tensor.base_dir, expected_dir)
 
 
-class OffsetCalcTest(unittest.TestCase):
-    """Test the offset calculation for the external tensor class."""
+class AlignmentTest(unittest.TestCase):
+    """Test the external data offset alignment policy."""
 
-    def test_align_offset_false(self):
-        # Tensor size > Align Threshold
-        current_offset = 20000
-        tensor_size = 1048
-        new_offset = external_data._compute_new_offset(  # pylint: disable=protected-access
-            current_offset, tensor_size, align_offset=False
-        )
-        self.assertEqual(current_offset, new_offset)
+    def test_dense_packing_is_the_default(self):
+        # No alignment object means offsets are never advanced.
+        large = external_data._DEFAULT_ALIGN_THRESHOLD + 1
+        tensors = [
+            ir.Tensor(np.zeros(large, dtype=np.uint8), name="a"),
+            ir.Tensor(np.zeros(large, dtype=np.uint8), name="b"),
+        ]
+        self.assertEqual(external_data._estimate_shard_size_bytes(tensors), 2 * large)
 
-    def test_align_with_small_align_threshold(self):
-        # Tensor size < Align Threshold
-        current_offset = 20000
-        tensor_size = 1048
-        new_offset = external_data._compute_new_offset(  # pylint: disable=protected-access
-            current_offset,
-            tensor_size,
-            align_threshold=1000,
+    def test_tensor_at_or_below_threshold_is_not_aligned(self):
+        self.assertEqual(
+            external_data._align_offset(20000, 1000, 65536, align_threshold=1000), 20000
         )
-        self.assertNotEqual(current_offset, new_offset)
 
-    def test_align_with_large_align_threshold(self):
-        # Tensor size > Align Threshold
-        current_offset = 20000
-        tensor_size = 1048
-        new_offset = external_data._compute_new_offset(  # pylint: disable=protected-access
-            current_offset,
-            tensor_size,
-        )
-        self.assertEqual(current_offset, new_offset)
+    def test_tensor_above_threshold_is_aligned(self):
+        new_offset = external_data._align_offset(20000, 1048, 65536, align_threshold=1000)
+        self.assertNotEqual(new_offset, 20000)
+        self.assertEqual(new_offset % 65536, 0)
 
-    def test_allocation_granularity_diff(self):
-        # Tensor size > Align Threshold
-        current_offset = 20000
-        tensor_size = 1048577
-        new_offset_1 = external_data._compute_new_offset(  # pylint: disable=protected-access
-            current_offset,
-            tensor_size,
-            allocation_granularity=4000,
+    def test_already_aligned_offset_is_unchanged(self):
+        self.assertEqual(
+            external_data._align_offset(65536 * 3, 1048, 65536, align_threshold=1000),
+            65536 * 3,
         )
-        new_offset_2 = external_data._compute_new_offset(  # pylint: disable=protected-access
-            current_offset,
-            tensor_size,
-        )
-        self.assertNotEqual(current_offset, new_offset_1)
-        self.assertNotEqual(current_offset, new_offset_2)
-        self.assertNotEqual(new_offset_1, new_offset_2)
+
+    def test_alignment_is_floored_at_one_page(self):
+        # A granularity below a 4KB page is raised to 4096.
+        offset = external_data._align_offset(20000, 1048, 4000, align_threshold=1000)
+        self.assertEqual(offset % 4096, 0)
+        self.assertEqual(offset, 20480)
 
 
 class OffloadExternalTensorTest(unittest.TestCase):
@@ -460,42 +445,77 @@ class OffloadExternalTensorTest(unittest.TestCase):
         self.assertEqual(external_tensor6.numpy().tobytes(), self.data_ext1_2.tobytes())
         self.assertEqual(external_tensor7.numpy().tobytes(), self.data_ext2_1.tobytes())
 
-    def test_external_data_sorted(self):
+    def test_external_data_written_in_declaration_order(self):
         model_with_external_data = external_data.unload_from_model(
             self.model_with_mixed_external_data,
             self.base_path,
             self.external_data_name,
         )
         file_path = os.path.join(self.base_path, self.external_data_name)
+        # Every tensor here is below the alignment threshold, so they are all in
+        # the packed prefix and keep their initializer declaration order.
+        initializers = model_with_external_data.graph.initializers
         expected_tensor_order = [
-            model_with_external_data.graph.initializers["tensor2"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor_ext1_1"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor1"].const_value.tobytes(),
-            model_with_external_data.graph.initializers[
-                "tensor_same_file"
-            ].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor_ext1_2"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["tensor_ext2_1"].const_value.tobytes(),
-            model_with_external_data.graph.initializers["custom_tensor"].const_value.tobytes(),
-        ]
-        sorted_tensor_order = [
-            self.data_float16.tobytes(),
-            self.data_ext1_1.tobytes(),
-            self.data.tobytes(),
-            self.data_other.tobytes(),
-            self.data_ext1_2.tobytes(),
-            self.data_ext2_1.tobytes(),
-            self.custom_data.tobytes(),
+            value.const_value.tobytes() for value in initializers.values()
         ]
         with open(file_path, "r+b") as data_file:
             current_offset = 0
-            for i, tensor_bytes in enumerate(sorted_tensor_order):
+            for i, tensor_bytes in enumerate(expected_tensor_order):
                 data_file.seek(current_offset)
-                tensor_length = len(tensor_bytes)
-                tensor_data = data_file.read(tensor_length)
-                current_offset += tensor_length
-                self.assertEqual(tensor_data, tensor_bytes)
-                self.assertEqual(tensor_data, expected_tensor_order[i])
+                tensor_data = data_file.read(len(tensor_bytes))
+                current_offset += len(tensor_bytes)
+                self.assertEqual(
+                    tensor_data,
+                    tensor_bytes,
+                    f"Tensor at declaration index {i} is not at the expected offset",
+                )
+
+    def test_tensors_are_packed_densely_in_declaration_order(self):
+        # Dense packing means offset N+1 == offset N + length N, with no gaps,
+        # and the on-disk order is exactly the declaration order.
+        threshold = external_data._DEFAULT_ALIGN_THRESHOLD
+        tensors = [
+            ir.Tensor(np.zeros(16, dtype=np.uint8), name="small_a"),
+            ir.Tensor(np.full(threshold + 1, 1, dtype=np.uint8), name="large_a"),
+            ir.Tensor(np.zeros(16, dtype=np.uint8), name="small_b"),
+            ir.Tensor(np.full(threshold + 1, 2, dtype=np.uint8), name="large_b"),
+        ]
+        result = external_data.convert_tensors_to_external(
+            tensors, self.base_path, "dense.bin"
+        )
+        self.assertEqual([t.name for t in result], [t.name for t in tensors])
+        expected_offset = 0
+        for original, external in zip(tensors, result):
+            self.assertEqual(external.offset, expected_offset, f"{external.name}")
+            expected_offset += original.nbytes
+        # The file has no padding at all.
+        self.assertEqual(
+            os.path.getsize(os.path.join(self.base_path, "dense.bin")),
+            sum(t.nbytes for t in tensors),
+        )
+
+    def test_alignment_is_opt_in_and_aligns_large_tensors(self):
+        alignment = 65536
+        threshold = external_data._DEFAULT_ALIGN_THRESHOLD
+        tensors = [
+            ir.Tensor(np.zeros(16, dtype=np.uint8), name="small_a"),
+            ir.Tensor(np.full(threshold + 1, 1, dtype=np.uint8), name="large_a"),
+            ir.Tensor(np.zeros(16, dtype=np.uint8), name="small_b"),
+            ir.Tensor(np.full(threshold + 1, 2, dtype=np.uint8), name="large_b"),
+        ]
+        result = external_data.convert_tensors_to_external(
+            tensors, self.base_path, "aligned.bin", alignment=alignment
+        )
+        # Declaration order is preserved regardless of the alignment policy.
+        self.assertEqual([t.name for t in result], [t.name for t in tensors])
+        by_name = {tensor.name: tensor for tensor in result}
+        # Small tensors are never aligned; large ones always are.
+        self.assertEqual(by_name["small_a"].offset, 0)
+        for name in ("large_a", "large_b"):
+            self.assertEqual(by_name[name].offset % alignment, 0)
+        # Reading back yields the original bytes despite the padding gaps.
+        for original, external in zip(tensors, result):
+            np.testing.assert_array_equal(external.numpy(), original.numpy())
 
 
 class ShardFilenameTest(unittest.TestCase):
@@ -591,77 +611,63 @@ class ShardTensorsTest(unittest.TestCase):
         self.assertIs(shards[1][0], t_small)
         self.assertRegex(logs.output[0], r"exceeds max_shard_size_bytes")
 
-    def test_sharding_accounts_for_alignment(self):
-        t0 = self._make_tensor("t0", external_data._ALIGN_THRESHOLD + 4)
-        t1 = self._make_tensor("t1", external_data._ALIGN_THRESHOLD + 4)
-        # Naively this would fit in one shard by nbytes sum, but alignment padding
-        # when writing forces a split.
-        shards = external_data._shard_tensors([t0, t1], t0.nbytes + t1.nbytes)
-        self.assertEqual(len(shards), 2)
-        self.assertEqual([len(s) for s in shards], [1, 1])
+    def test_sharding_is_dense_by_default(self):
+        # Without alignment a shard's size is exactly the sum of its tensors,
+        # so two tensors summing to the limit fit in a single shard.
+        t0 = self._make_uint8_tensor("t0", 1000)
+        t1 = self._make_uint8_tensor("t1", 1000)
+        shards = external_data._shard_tensors([t0, t1], 2000)
+        self.assertEqual(len(shards), 1)
 
-    def test_incremental_size_matches_reference_estimate(self):
-        # The incremental accumulator used by _shard_tensors must match the
-        # reference size simulation for arbitrary mixes of tensor sizes,
-        # especially around the alignment threshold.
-        threshold = external_data._ALIGN_THRESHOLD
+    def test_sharding_accounts_for_alignment_when_enabled(self):
+        alignment = 65536
+        t0 = self._make_uint8_tensor("t0", external_data._DEFAULT_ALIGN_THRESHOLD + 4)
+        t1 = self._make_uint8_tensor("t1", external_data._DEFAULT_ALIGN_THRESHOLD + 4)
+        # These fit in one shard by raw byte sum, but the alignment padding
+        # inserted before ``t1`` when writing forces a split.
+        shards = external_data._shard_tensors([t0, t1], t0.nbytes + t1.nbytes, alignment)
+        self.assertEqual([len(shard) for shard in shards], [1, 1])
+
+    def test_shards_never_exceed_the_limit_they_estimate(self):
+        # Property test: for arbitrary size mixes, with and without alignment,
+        # every shard must fit within the limit once laid out on disk (unless it
+        # holds a single oversized tensor, which is allowed by contract).
+        alignment = 65536
+        threshold = external_data._DEFAULT_ALIGN_THRESHOLD
         size_choices = [1, 100, threshold - 1, threshold, threshold + 1, 3 * threshold]
         rng = np.random.default_rng(0)
-        for _ in range(500):
-            count = int(rng.integers(0, 100))
+        for policy in (None, alignment):
+            for _ in range(200):
+                count = int(rng.integers(1, 40))
+                sizes = [int(rng.choice(size_choices)) for _ in range(count)]
+                tensors = [self._make_uint8_tensor(f"t{i}", s) for i, s in enumerate(sizes)]
+                limit = int(rng.choice([threshold, 4 * threshold, 16 * threshold]))
+                shards = external_data._shard_tensors(tensors, limit, policy)
+                # Every tensor is placed exactly once, in declaration order.
+                self.assertEqual(
+                    [t.name for shard in shards for t in shard],
+                    [t.name for t in tensors],
+                )
+                for shard in shards:
+                    size = external_data._estimate_shard_size_bytes(shard, policy)
+                    if len(shard) > 1:
+                        self.assertLessEqual(size, limit, f"sizes={sizes} limit={limit}")
+
+    def test_estimated_size_matches_written_size(self):
+        # The size the sharder predicts must match what actually lands on disk.
+        alignment = 65536
+        for policy in (None, alignment):
             tensors = [
-                self._make_tensor(f"t{i}", int(rng.choice(size_choices))) for i in range(count)
+                self._make_uint8_tensor("small", 128),
+                self._make_uint8_tensor("large", external_data._DEFAULT_ALIGN_THRESHOLD + 4),
+                self._make_uint8_tensor("small2", 64),
             ]
-            accumulator = external_data._ShardSizeAccumulator()
-            for tensor in tensors:
-                accumulator.add(tensor)
-            self.assertEqual(
-                accumulator.size,
-                external_data._estimate_shard_size_bytes(tensors),
-            )
-
-    def test_incremental_size_at_strict_alignment_threshold_boundary(self):
-        # Round-2 review: the float32 ``nbytes // 4`` helper collapses
-        # ``threshold + 1`` back down to ``threshold`` because the floor
-        # divide rounds away the 1-byte excess. Use exact-byte uint8
-        # tensors to actually exercise the strict ``> _ALIGN_THRESHOLD``
-        # branch in :meth:`_ShardSizeAccumulator.add`.
-        threshold = external_data._ALIGN_THRESHOLD
-        for sizes in (
-            [threshold - 1, threshold, threshold + 1],
-            [threshold + 1, threshold, threshold - 1],
-            [threshold + 1, threshold + 1, threshold - 1, threshold],
-        ):
-            tensors = [self._make_uint8_tensor(f"t{i}", s) for i, s in enumerate(sizes)]
-            for tensor, expected_size in zip(tensors, sizes):
-                self.assertEqual(tensor.nbytes, expected_size)
-            accumulator = external_data._ShardSizeAccumulator()
-            for tensor in tensors:
-                accumulator.add(tensor)
-            self.assertEqual(
-                accumulator.size,
-                external_data._estimate_shard_size_bytes(tensors),
-                f"sizes={sizes}",
-            )
-
-    def test_incremental_size_invariant_under_add_order(self):
-        # The accumulator is fed tensors in the order ``_shard_tensors`` sees
-        # them (i.e. unsorted), but :func:`_estimate_shard_size_bytes` sorts
-        # internally. Their results must agree regardless of the input order.
-        threshold = external_data._ALIGN_THRESHOLD
-        size_choices = [1, 100, threshold - 1, threshold, threshold + 1, 3 * threshold]
-        rng = np.random.default_rng(123)
-        for _ in range(200):
-            count = int(rng.integers(1, 40))
-            sizes = [int(rng.choice(size_choices)) for _ in range(count)]
-            tensors = [self._make_uint8_tensor(f"t{i}", s) for i, s in enumerate(sizes)]
-            reference = external_data._estimate_shard_size_bytes(tensors)
-            shuffled = list(tensors)
-            rng.shuffle(shuffled)
-            accumulator = external_data._ShardSizeAccumulator()
-            for tensor in shuffled:
-                accumulator.add(tensor)
-            self.assertEqual(accumulator.size, reference)
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                external_data.convert_tensors_to_external(
+                    tensors, tmp_dir, "estimate.bin", alignment=policy
+                )
+                actual = os.path.getsize(os.path.join(tmp_dir, "estimate.bin"))
+            self.assertEqual(external_data._estimate_shard_size_bytes(tensors, policy), actual)
 
 
 class ShardedExternalDataTest(unittest.TestCase):
@@ -872,6 +878,171 @@ class ShardedExternalDataTest(unittest.TestCase):
             )
         with open(foreign, "rb") as f:
             self.assertEqual(f.read(), b"foreign")
+
+
+class ParallelWriteTest(unittest.TestCase):
+    """Tests for the concurrent external data write pipeline."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.base_path = self.temp_dir.name
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _make_tensors(self, count=24, size=40_000):
+        rng = np.random.default_rng(7)
+        return [
+            ir.Tensor(rng.integers(0, 255, size=size, dtype=np.uint8), name=f"t{i}")
+            for i in range(count)
+        ]
+
+    def test_parallel_output_is_byte_identical_to_serial(self):
+        tensors = self._make_tensors()
+        serial_dir = os.path.join(self.base_path, "serial")
+        parallel_dir = os.path.join(self.base_path, "parallel")
+        os.makedirs(serial_dir)
+        os.makedirs(parallel_dir)
+
+        serial = external_data.convert_tensors_to_external(
+            tensors, serial_dir, "model.data", max_workers=None
+        )
+        parallel = external_data.convert_tensors_to_external(
+            tensors, parallel_dir, "model.data", max_workers=8
+        )
+
+        with open(os.path.join(serial_dir, "model.data"), "rb") as f:
+            serial_bytes = f.read()
+        with open(os.path.join(parallel_dir, "model.data"), "rb") as f:
+            parallel_bytes = f.read()
+        self.assertEqual(serial_bytes, parallel_bytes)
+
+        # Offsets, lengths and order must match too.
+        self.assertEqual(
+            [(t.name, t.offset, t.length) for t in serial],
+            [(t.name, t.offset, t.length) for t in parallel],
+        )
+
+    def test_parallel_roundtrip_preserves_values(self):
+        tensors = self._make_tensors()
+        result = external_data.convert_tensors_to_external(
+            tensors, self.base_path, "model.data", max_workers=4
+        )
+        for original, external in zip(tensors, result):
+            np.testing.assert_array_equal(external.numpy(), original.numpy())
+
+    def test_parallel_with_alignment_matches_serial(self):
+        alignment = 4096
+        tensors = self._make_tensors(count=12)
+        serial_dir = os.path.join(self.base_path, "serial")
+        parallel_dir = os.path.join(self.base_path, "parallel")
+        os.makedirs(serial_dir)
+        os.makedirs(parallel_dir)
+        external_data.convert_tensors_to_external(
+            tensors, serial_dir, "m.data", alignment=alignment, align_threshold=1024
+        )
+        external_data.convert_tensors_to_external(
+            tensors,
+            parallel_dir,
+            "m.data",
+            max_workers=6,
+            alignment=alignment,
+            align_threshold=1024,
+        )
+        with open(os.path.join(serial_dir, "m.data"), "rb") as f:
+            serial_bytes = f.read()
+        with open(os.path.join(parallel_dir, "m.data"), "rb") as f:
+            parallel_bytes = f.read()
+        # Padding bytes must be zeros in both cases, not stale file content.
+        self.assertEqual(serial_bytes, parallel_bytes)
+
+    def test_callback_is_invoked_once_per_tensor(self):
+        tensors = self._make_tensors(count=16)
+        seen = []
+        lock = threading.Lock()
+
+        def callback(tensor, info):
+            with lock:
+                seen.append((tensor.name, info.index, info.total))
+
+        external_data.convert_tensors_to_external(
+            tensors, self.base_path, "model.data", callback=callback, max_workers=8
+        )
+        self.assertEqual(len(seen), len(tensors))
+        self.assertEqual({name for name, _, _ in seen}, {t.name for t in tensors})
+        self.assertEqual(sorted(index for _, index, _ in seen), list(range(len(tensors))))
+        self.assertTrue(all(total == len(tensors) for _, _, total in seen))
+
+    def test_exception_in_worker_propagates(self):
+        class ExplodingTensor(ir.Tensor):
+            def tofile(self, file):
+                raise RuntimeError("boom")
+
+        tensors = self._make_tensors(count=4)
+        tensors[2] = ExplodingTensor(np.zeros(40_000, dtype=np.uint8), name=tensors[2].name)
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            external_data.convert_tensors_to_external(
+                tensors, self.base_path, "model.data", max_workers=4
+            )
+
+    def test_byte_budget_bounds_in_flight_bytes(self):
+        budget = external_data._ByteBudget(1000)
+        first = budget.acquire(600)
+        self.assertEqual(first, 600)
+        acquired = threading.Event()
+
+        def worker():
+            budget.acquire(600)
+            acquired.set()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        # The second acquire must block while the first is outstanding.
+        self.assertFalse(acquired.wait(timeout=0.2))
+        budget.release(first)
+        self.assertTrue(acquired.wait(timeout=5))
+        thread.join()
+
+    def test_byte_budget_admits_tensor_larger_than_capacity(self):
+        # An oversized tensor must not deadlock; it is admitted on its own.
+        budget = external_data._ByteBudget(100)
+        amount = budget.acquire(10_000)
+        self.assertEqual(amount, 100)
+        budget.release(amount)
+
+    def test_parallel_sharded_save_matches_serial(self):
+        def build_model():
+            rng = np.random.default_rng(11)
+            graph = ir.Graph(inputs=[], outputs=[], nodes=[], initializers=[], name="g")
+            for i in range(12):
+                tensor = ir.Tensor(
+                    rng.integers(0, 255, size=30_000, dtype=np.uint8), name=f"w{i}"
+                )
+                graph.register_initializer(ir.Value(name=f"w{i}", const_value=tensor))
+            return ir.Model(graph, ir_version=10)
+
+        serial_dir = os.path.join(self.base_path, "serial")
+        parallel_dir = os.path.join(self.base_path, "parallel")
+        os.makedirs(serial_dir)
+        os.makedirs(parallel_dir)
+        external_data.unload_from_model(
+            build_model(), serial_dir, "model.data", max_shard_size_bytes=100_000
+        )
+        external_data.unload_from_model(
+            build_model(),
+            parallel_dir,
+            "model.data",
+            max_shard_size_bytes=100_000,
+            max_workers=4,
+        )
+        serial_files = sorted(os.listdir(serial_dir))
+        self.assertEqual(serial_files, sorted(os.listdir(parallel_dir)))
+        self.assertGreater(len(serial_files), 1)
+        for name in serial_files:
+            with open(os.path.join(serial_dir, name), "rb") as f:
+                expected = f.read()
+            with open(os.path.join(parallel_dir, name), "rb") as f:
+                self.assertEqual(f.read(), expected, name)
 
 
 if __name__ == "__main__":

--- a/src/onnx_ir/external_data_test.py
+++ b/src/onnx_ir/external_data_test.py
@@ -76,11 +76,7 @@ class AlignmentTest(unittest.TestCase):
     def test_dense_packing_is_the_default(self):
         # No alignment object means offsets are never advanced.
         large = external_data._DEFAULT_ALIGN_THRESHOLD + 1
-        tensors = [
-            ir.Tensor(np.zeros(large, dtype=np.uint8), name="a"),
-            ir.Tensor(np.zeros(large, dtype=np.uint8), name="b"),
-        ]
-        self.assertEqual(external_data._estimate_shard_size_bytes(tensors), 2 * large)
+        self.assertEqual(external_data._align_offset(large, large, None, large - 1), large)
 
     def test_tensor_at_or_below_threshold_is_not_aligned(self):
         self.assertEqual(
@@ -643,6 +639,8 @@ class ShardFilenameTest(unittest.TestCase):
             "model.weights.bin": "model-00002-of-00009.weights.bin",
             "archive.tar.gz": "archive-00002-of-00009.tar.gz",
             ".weights.data": ".weights-00002-of-00009.data",
+            "qwen2.5.onnx.data": "qwen2.5-00002-of-00009.onnx.data",
+            "llama-3.1-8b.onnx.data": "llama-3.1-8b-00002-of-00009.onnx.data",
         }
         for filename, expected in cases.items():
             with self.subTest(filename=filename):
@@ -768,7 +766,12 @@ class ShardTensorsTest(unittest.TestCase):
                     [t.name for t in tensors],
                 )
                 for shard in shards:
-                    size = external_data._estimate_shard_size_bytes(shard, policy)
+                    size = 0
+                    for tensor in shard:
+                        size = external_data._align_offset(
+                            size, tensor.nbytes, policy, threshold
+                        )
+                        size += tensor.nbytes
                     if len(shard) > 1:
                         self.assertLessEqual(size, limit, f"sizes={sizes} limit={limit}")
 
@@ -786,7 +789,16 @@ class ShardTensorsTest(unittest.TestCase):
                     tensors, tmp_dir, "estimate.bin", alignment=policy
                 )
                 actual = os.path.getsize(os.path.join(tmp_dir, "estimate.bin"))
-            self.assertEqual(external_data._estimate_shard_size_bytes(tensors, policy), actual)
+            expected = 0
+            for tensor in tensors:
+                expected = external_data._align_offset(
+                    expected,
+                    tensor.nbytes,
+                    policy,
+                    external_data._DEFAULT_ALIGN_THRESHOLD,
+                )
+                expected += tensor.nbytes
+            self.assertEqual(expected, actual)
 
 
 class ShardedExternalDataTest(unittest.TestCase):
@@ -1106,6 +1118,60 @@ class ParallelWriteTest(unittest.TestCase):
             external_data.convert_tensors_to_external(
                 tensors, self.base_path, "model.data", max_workers=4
             )
+
+    def test_exception_cancels_pending_writes(self):
+        blocker_started = threading.Event()
+        release_blockers = threading.Event()
+        started_count = 0
+        started_lock = threading.Lock()
+
+        class BlockingTensor(ir.Tensor):
+            def tofile(self, file):
+                nonlocal started_count
+                with started_lock:
+                    started_count += 1
+                blocker_started.set()
+                release_blockers.wait()
+                time.sleep(0.1)
+                super().tofile(file)
+
+        class ExplodingTensor(ir.Tensor):
+            def tofile(self, file):
+                blocker_started.wait()
+                release_blockers.set()
+                raise RuntimeError("boom")
+
+        tensors = [
+            BlockingTensor(np.zeros(8, dtype=np.uint8), name=f"t{i}") for i in range(20)
+        ]
+        tensors.insert(1, ExplodingTensor(np.zeros(8, dtype=np.uint8), name="exploding"))
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            external_data.convert_tensors_to_external(
+                tensors, self.base_path, "model.data", max_workers=2
+            )
+
+        self.assertLess(started_count, 20)
+
+    def test_invalid_write_options_raise(self):
+        tensors = self._make_tensors(count=1)
+        invalid_options = (
+            ("max_workers", 0),
+            ("max_in_flight_bytes", 0),
+            ("alignment", 0),
+            ("align_threshold", -1),
+        )
+        for option, value in invalid_options:
+            with (
+                self.subTest(option=option),
+                self.assertRaisesRegex(ValueError, option),
+            ):
+                external_data.convert_tensors_to_external(
+                    tensors,
+                    self.base_path,
+                    f"{option}.data",
+                    **{option: value},
+                )
 
     def test_shared_lazy_tensor_is_evaluated_once_across_shards(self):
         evaluation_count = 0

--- a/src/onnx_ir/tensor_adapters_test.py
+++ b/src/onnx_ir/tensor_adapters_test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import os
 import tempfile
 import unittest
 
@@ -211,6 +212,70 @@ class TorchDtypeConversionTest(unittest.TestCase):
             data = tmp.read()
         self.assertEqual(data, expected_manual)
         self.assertEqual(tensor.tobytes(), expected_manual)
+
+
+def _accelerator_device() -> str | None:
+    """Return an available non-CPU device, or None."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return None
+
+
+class TorchTensorConcurrentSaveTest(unittest.TestCase):
+    """Saving torch-backed weights concurrently, including on an accelerator."""
+
+    def _save(self, tensors, tmp_dir, name, max_workers):
+        graph = ir.Graph(inputs=[], outputs=[], nodes=[], initializers=[], name="g")
+        for i, torch_tensor in enumerate(tensors):
+            tensor_name = f"w{i}"
+
+            def make(t=torch_tensor, n=tensor_name):
+                return tensor_adapters.TorchTensor(t.to(torch.float16), name=n)
+
+            lazy = ir.LazyTensor(
+                make,
+                dtype=ir.DataType.FLOAT16,
+                shape=ir.Shape(tuple(torch_tensor.shape)),
+                name=tensor_name,
+            )
+            graph.register_initializer(ir.Value(name=tensor_name, const_value=lazy))
+        model = ir.Model(graph, ir_version=10)
+        path = os.path.join(tmp_dir, name)
+        os.makedirs(path)
+        ir.save(
+            model,
+            os.path.join(path, "model.onnx"),
+            external_data="model.data",
+            **({} if max_workers is None else {"max_workers": max_workers}),
+        )
+        with open(os.path.join(path, "model.data"), "rb") as f:
+            return f.read()
+
+    def test_cpu_weights_survive_concurrent_writes(self):
+        # The device-to-host copy and dtype cast both happen inside tofile on
+        # a worker thread, so the result must not depend on the worker count.
+        tensors = [torch.full((512,), i, dtype=torch.bfloat16) for i in range(8)]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            serial = self._save(tensors, tmp_dir, "serial", None)
+            parallel = self._save(tensors, tmp_dir, "parallel", 4)
+        self.assertEqual(serial, parallel)
+
+    def test_accelerator_weights_survive_concurrent_writes(self):
+        device = _accelerator_device()
+        if device is None:
+            self.skipTest("no accelerator available")
+        tensors = [
+            torch.full((512,), i, dtype=torch.bfloat16, device=device) for i in range(8)
+        ]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            serial = self._save(tensors, tmp_dir, "serial", None)
+            parallel = self._save(tensors, tmp_dir, "parallel", 8)
+        self.assertEqual(serial, parallel)
+        # Sanity check that the values actually round-tripped, not just matched.
+        expected = b"".join(t.to(torch.float16).cpu().numpy().tobytes() for t in tensors)
+        self.assertEqual(serial, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Saving large external data currently alternates tensor materialization (lazy evaluation and dtype conversion) with disk writes. This leaves compute and I/O idle in turn and becomes especially expensive for multi-GB models.

This PR overlaps materialization and I/O, adds bounded parallel writes across tensors and shards, and simplifies the external-data layout.

## Parallel write pipeline

Offsets are computed before writing, so every tensor owns a disjoint byte range.

- A single-file writer selects a cheap serial path or a parallel path with one independent `r+b` handle per worker.
- Sharded saves can write multiple shard files concurrently. The total worker count is split between shard drivers and per-shard writers rather than creating nested `max_workers ** 2` pools.
- A shared byte budget (`max_in_flight_bytes`, default 1 GiB) bounds materialized tensor memory across all workers and shards. At most one oversized tensor is admitted in addition to the regular budget.
- `ExternalTensor` file-to-file copies reserve only their 1 MiB fallback buffer. On Linux regular files they use `copy_file_range()` to avoid userspace byte buffers; unsupported platforms/filesystems transparently use bounded chunked copies.
- Callbacks remain serialized, and shard metadata allows clients to render one progress bar per shard.

## Layout and sharding

- Tensors are written in declaration order instead of being sorted by size. Exporters normally emit initializers in topological order, keeping weights consumed together adjacent on disk.
- The default layout is dense. Optional integer `alignment` and `align_threshold` parameters retain aligned layouts for runtimes that require them.
- `max_shard_size_bytes` writes declaration-order shards while accounting for optional alignment padding.
- Compound suffixes are preserved when naming shards: `model.onnx.data` becomes `model-00001-of-00003.onnx.data`.

## Transactional writes

Each external-data file is written to a temporary file in the destination directory and atomically moved into place only after all tensor writes succeed.

- A failed single-file write leaves the previous destination unchanged and removes the temporary file.
- Same-destination `ExternalTensor`s stream directly into the temporary file instead of being fully materialized in memory, then become invalid only after successful replacement.
- Existing file permissions and destination symlinks are preserved.

## Behavior changes in 1.1.0

- **Dense packing is now the default.** Previously tensors larger than 1 MiB were aligned to 64 KiB offsets. Pass `alignment=65536` to retain the previous layout.
- **Declaration order replaces size-based ordering.** Initializer data now follows model declaration order.
- **Single-file replacement is transactional.** The destination is replaced only after a successful write; failures preserve the previous file. Atomic replacement creates a new inode, so other hardlinks continue to reference the old contents.
- **Concurrent callback order is unspecified.** With `max_workers > 1`, callbacks are lock-serialized but may arrive out of index order; `CallbackInfo.index` continues to identify the tensor.
- **Sharded writes reject destination collisions.** Existing shard files must be removed or a different destination selected.

These changes are also documented on the public `save()` API with `versionadded:: 1.1.0` and `versionchanged:: 1.1.0` directives.

## Benchmark

Qwen2.5-7B bf16-to-fp16 save, 9 x 2 GiB shards, 8 workers:

| configuration | time |
|---|---:|
| serial | 256.67 s |
| 512 MiB budget | 107.18 s |
| **1 GiB budget** | **69.78 s** |
| 2 GiB budget | 79.48 s |

The 1 GiB budget provided the best measured throughput on this workload while retaining a predictable memory bound.

## Tests

Coverage includes serial/parallel byte equality, aligned and dense layouts, sharding and shard naming, callback metadata and concurrency, worker-count limits, shared/oversized byte budgets, exception propagation, Linux kernel-copy fallback behavior, same-path external tensors, atomic failure recovery, permission and symlink preservation, and model round trips.