### PR TITLE
Declare `packaging` as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license-files = ["LICEN[CS]E*"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
 ]
-dependencies = ["numpy", "onnx>=1.16", "typing_extensions>=4.10", "ml_dtypes>=0.5.0", "sympy>=1.13"]
+dependencies = ["numpy", "onnx>=1.16", "typing_extensions>=4.10", "ml_dtypes>=0.5.0", "sympy>=1.13", "packaging"]
 
 [project.urls]
 Homepage = "https://onnx.ai/ir-py"


### PR DESCRIPTION
Fixes #479.

## Problem

`onnx_ir` imports `packaging` at module scope, but `packaging` was only declared in `requirements-dev.txt` and the `noxfile.py` test dependencies — never in the project's runtime `dependencies`. A clean `pip install onnx-ir` therefore produces an installation where `import onnx_ir` fails immediately:

```console
$ /tmp/venv/bin/pip install onnx-ir
$ /tmp/venv/bin/python -c "import onnx_ir"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import onnx_ir
  File ".../onnx_ir/__init__.py", line 183, in <module>
    from onnx_ir._safetensors import save_safetensors
  File ".../onnx_ir/_safetensors/__init__.py", line 18, in <module>
    import packaging.version
ModuleNotFoundError: No module named 'packaging'
```

The failing import sits on the top-level `import onnx_ir` chain (`__init__.py:183` → `_safetensors/__init__.py:18`), so the package is unusable rather than merely missing an optional feature. `packaging` is imported at module scope in `_version_utils.py:8` as well.

## Why CI never caught it

`packaging` is listed in `requirements-dev.txt:20` and `noxfile.py:19`, so every CI job and every developer environment already has it installed. It is also present incidentally in most real environments as a transitive dependency of common tooling. It only surfaces in a minimal environment that installs `onnx-ir` and nothing else.

## Fix

One line — add `packaging` to `dependencies` in `pyproject.toml`.

## Verification

Built a wheel from this branch and from `main`, and installed each into a bare venv:

| | `pip show onnx-ir` → `Requires` | `import onnx_ir` |
|---|---|---|
| `main` | `ml_dtypes, numpy, onnx, sympy, typing_extensions` | `ModuleNotFoundError: No module named 'packaging'` |
| this PR | `ml_dtypes, numpy, onnx, packaging, sympy, typing_extensions` | OK |

Existing suite unaffected: `pytest src` → 1757 passed, 1 skipped, 23 subtests passed. `lintrunner` clean.

## Possible follow-ups (not in this PR)

Happy to do either as a separate change if wanted:

1. A CI job that installs the built wheel into a bare venv and runs `python -c "import onnx_ir"`, to catch undeclared runtime dependencies in general — the current jobs install dev requirements, which masks them by construction.
2. The only uses are `packaging.version.parse` for simple comparisons, so they could move to `importlib.metadata` and drop the dependency instead. Declaring it seemed like the smaller and more conventional fix, but I'm happy to go the other way if you prefer fewer runtime dependencies.

## Context

Found while smoke-testing a fresh PyPI release of [`onnx-shape-inference`](https://github.com/justinchuby/onnx-shape-inference) (which depends on `onnx-ir`) in a clean venv — the test failed on `import onnx_ir` before reaching any of that project's own code.
