### PR TITLE
[passes] Preserve BatchNormalization training semantics

### DIFF
--- a/src/onnx_ir/passes/common/unused_removal.py
+++ b/src/onnx_ir/passes/common/unused_removal.py
@@ -33,22 +33,16 @@ def _remove_unused_optional_outputs(
         return
 
     if node.op_type == "BatchNormalization":
-        # BatchNormalization op has 3 outputs: Y, running_mean, running_var
-        # If running_mean and running_var are not used, remove them, and the training_mode attribute
-        def is_used_output(i: int) -> bool:
-            if i < len(node.outputs):
-                val = node.outputs[i]
-                return val in graph_outputs or bool(val.uses())
-            return False
-
-        if is_used_output(1) or is_used_output(2):
+        training_mode = node.attributes.get("training_mode")
+        # Changing training mode to inference changes Y because training uses batch statistics.
+        # Only remove training outputs when inference mode is statically known.
+        if training_mode is not None and (
+            training_mode.is_ref()
+            or training_mode.type != ir.AttributeType.INT
+            or training_mode.as_int() != 0
+        ):
             return
-        if len(node.outputs) > 1:
-            node.outputs[1].name = ""
-        if len(node.outputs) > 2:
-            node.outputs[2].name = ""
         node.attributes.pop("training_mode", None)
-        return
 
     optional_info = []
     for o in op_schema.outputs:

--- a/src/onnx_ir/passes/common/unused_removal.py
+++ b/src/onnx_ir/passes/common/unused_removal.py
@@ -33,6 +33,9 @@ def _remove_unused_optional_outputs(
         return
 
     if node.op_type == "BatchNormalization":
+        # Before opset 14, output arity selects training or inference behavior.
+        if "training_mode" not in op_schema.attributes:
+            return
         training_mode = node.attributes.get("training_mode")
         # Changing training mode to inference changes Y because training uses batch statistics.
         # Only remove training outputs when inference mode is statically known.

--- a/src/onnx_ir/passes/common/unused_removal_test.py
+++ b/src/onnx_ir/passes/common/unused_removal_test.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 import onnx
+import onnxruntime as ort
 from onnx.reference import ReferenceEvaluator
 
 import onnx_ir as ir
@@ -16,6 +17,15 @@ class RemoveUnusedTest(unittest.TestCase):
         onnx_ir.passes.common.RemoveUnusedNodesPass()(model_ir)
         model = ir.serde.serialize_model(model_ir)
         return model
+
+    def batchnorm_feeds(self):
+        return {
+            "x": np.array([[1.0, 2.0], [3.0, 6.0]], dtype=np.float32),
+            "scale": np.ones(2, dtype=np.float32),
+            "bias": np.zeros(2, dtype=np.float32),
+            "mean": np.array([100.0, -100.0], dtype=np.float32),
+            "var": np.array([4.0, 9.0], dtype=np.float32),
+        }
 
     def batchnorm_model(self, training_mode=None, *, include_running_outputs=False):
         training_attribute = (
@@ -39,6 +49,23 @@ class RemoveUnusedTest(unittest.TestCase):
                 y, running_mean, running_var =
                     BatchNormalization {training_attribute} (x, scale, bias, mean, var)
             }}
+        """
+        )
+
+    def legacy_batchnorm_model(self):
+        return onnx.parser.parse_model(
+            """
+            <ir_version: 10, opset_import: [ "" : 9]>
+            agraph (
+                float[2, 2] x,
+                float[2] scale,
+                float[2] bias,
+                float[2] mean,
+                float[2] var
+            ) => (float[2, 2] y) {
+                y, running_mean, running_var, saved_mean, saved_var =
+                    BatchNormalization (x, scale, bias, mean, var)
+            }
         """
         )
 
@@ -240,13 +267,7 @@ class RemoveUnusedTest(unittest.TestCase):
 
     def test_preserve_unused_optional_outputs_batchnorm_in_training_mode(self):
         model = self.batchnorm_model(training_mode=1)
-        feeds = {
-            "x": np.array([[1.0, 2.0], [3.0, 6.0]], dtype=np.float32),
-            "scale": np.ones(2, dtype=np.float32),
-            "bias": np.zeros(2, dtype=np.float32),
-            "mean": np.array([100.0, -100.0], dtype=np.float32),
-            "var": np.array([4.0, 9.0], dtype=np.float32),
-        }
+        feeds = self.batchnorm_feeds()
         original_output = ReferenceEvaluator(model).run(None, feeds)[0]
         expected_output = (feeds["x"] - feeds["x"].mean(axis=0)) / np.sqrt(
             feeds["x"].var(axis=0) + 1e-5
@@ -259,6 +280,25 @@ class RemoveUnusedTest(unittest.TestCase):
         self.assertEqual({attr.name: attr.i for attr in node.attribute}, {"training_mode": 1})
         onnx.checker.check_model(model)
         optimized_output = ReferenceEvaluator(model).run(None, feeds)[0]
+        np.testing.assert_allclose(optimized_output, original_output, rtol=1e-5, atol=1e-5)
+
+    def test_preserve_unused_outputs_batchnorm_opset9(self):
+        model = self.legacy_batchnorm_model()
+        onnx.checker.check_model(model)
+        feeds = self.batchnorm_feeds()
+        original_output = ort.InferenceSession(model.SerializeToString()).run(None, feeds)[0]
+        expected_output = (feeds["x"] - feeds["x"].mean(axis=0)) / np.sqrt(
+            feeds["x"].var(axis=0) + 1e-5
+        )
+        np.testing.assert_allclose(original_output, expected_output, rtol=1e-5, atol=1e-5)
+
+        model = self.remove_unused_nodes(model)
+        self.assertEqual(
+            list(model.graph.node[0].output),
+            ["y", "running_mean", "running_var", "saved_mean", "saved_var"],
+        )
+        onnx.checker.check_model(model)
+        optimized_output = ort.InferenceSession(model.SerializeToString()).run(None, feeds)[0]
         np.testing.assert_allclose(optimized_output, original_output, rtol=1e-5, atol=1e-5)
 
     def test_remove_unused_optional_outputs_batchnorm_in_inference_mode(self):

--- a/src/onnx_ir/passes/common/unused_removal_test.py
+++ b/src/onnx_ir/passes/common/unused_removal_test.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import unittest
 
+import numpy as np
 import onnx
+from onnx.reference import ReferenceEvaluator
 
 import onnx_ir as ir
 import onnx_ir.passes.common
@@ -14,6 +16,31 @@ class RemoveUnusedTest(unittest.TestCase):
         onnx_ir.passes.common.RemoveUnusedNodesPass()(model_ir)
         model = ir.serde.serialize_model(model_ir)
         return model
+
+    def batchnorm_model(self, training_mode=None, *, include_running_outputs=False):
+        training_attribute = (
+            "" if training_mode is None else f"<training_mode={training_mode}>"
+        )
+        graph_outputs = (
+            "float[2, 2] y, float[2] running_mean, float[2] running_var"
+            if include_running_outputs
+            else "float[2, 2] y"
+        )
+        return onnx.parser.parse_model(
+            f"""
+            <ir_version: 10, opset_import: [ "" : 17]>
+            agraph (
+                float[2, 2] x,
+                float[2] scale,
+                float[2] bias,
+                float[2] mean,
+                float[2] var
+            ) => ({graph_outputs}) {{
+                y, running_mean, running_var =
+                    BatchNormalization {training_attribute} (x, scale, bias, mean, var)
+            }}
+        """
+        )
 
     def test_remove_unused_nodes(self):
         model = onnx.parser.parse_model(
@@ -211,39 +238,87 @@ class RemoveUnusedTest(unittest.TestCase):
         self.assertEqual(model.graph.node[2].op_type, "LayerNormalization")
         self.assertEqual(list(model.graph.node[2].output), ["z", "", "InvStdDev"])
 
-    def test_remove_trailing_unused_optional_outputs_batchnorm(self):
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 10, opset_import: [ "" : 17]>
-            agraph (float[1, 3, 5, 5] x, float[3] scale, float[3] B) => (float[1, 3, 5, 5] z) {
-                z, mean_out, var_out = BatchNormalization <training_mode=1> (x, scale, B, mean, var)
-            }
-        """
+    def test_preserve_unused_optional_outputs_batchnorm_in_training_mode(self):
+        model = self.batchnorm_model(training_mode=1)
+        feeds = {
+            "x": np.array([[1.0, 2.0], [3.0, 6.0]], dtype=np.float32),
+            "scale": np.ones(2, dtype=np.float32),
+            "bias": np.zeros(2, dtype=np.float32),
+            "mean": np.array([100.0, -100.0], dtype=np.float32),
+            "var": np.array([4.0, 9.0], dtype=np.float32),
+        }
+        original_output = ReferenceEvaluator(model).run(None, feeds)[0]
+        expected_output = (feeds["x"] - feeds["x"].mean(axis=0)) / np.sqrt(
+            feeds["x"].var(axis=0) + 1e-5
         )
-        self.assertEqual(len(model.graph.node[0].attribute), 1)
-        model = self.remove_unused_nodes(model)
-        self.assertEqual(len(model.graph.node), 1)
-        self.assertEqual(model.graph.node[0].op_type, "BatchNormalization")
-        # Check that both the mean/var outputs are removed, and training_mode attribute is removed.
-        self.assertEqual(list(model.graph.node[0].output), ["z"])
-        self.assertEqual(len(model.graph.node[0].attribute), 0)
+        np.testing.assert_allclose(original_output, expected_output, rtol=1e-5, atol=1e-5)
 
-    def test_avoid_remove_used_optional_outputs_batchnorm(self):
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 10, opset_import: [ "" : 17]>
-            agraph (float[1, 3, 5, 5] x, float[3] scale, float[3] B) => (float[1, 3, 5, 5] z, float[3] mean_out, float[3] var_out) {
-                z, mean_out, var_out = BatchNormalization <training_mode=1> (x, scale, B, mean, var)
-            }
-        """
-        )
-        self.assertEqual(len(model.graph.node[0].attribute), 1)
         model = self.remove_unused_nodes(model)
-        self.assertEqual(len(model.graph.node), 1)
-        self.assertEqual(model.graph.node[0].op_type, "BatchNormalization")
-        # Check that the mean/var outputs are NOT removed, and training_mode attribute is NOT removed.
-        self.assertEqual(list(model.graph.node[0].output), ["z", "mean_out", "var_out"])
-        self.assertEqual(len(model.graph.node[0].attribute), 1)
+        node = model.graph.node[0]
+        self.assertEqual(list(node.output), ["y", "running_mean", "running_var"])
+        self.assertEqual({attr.name: attr.i for attr in node.attribute}, {"training_mode": 1})
+        onnx.checker.check_model(model)
+        optimized_output = ReferenceEvaluator(model).run(None, feeds)[0]
+        np.testing.assert_allclose(optimized_output, original_output, rtol=1e-5, atol=1e-5)
+
+    def test_remove_unused_optional_outputs_batchnorm_in_inference_mode(self):
+        for training_mode in (None, 0):
+            with self.subTest(training_mode=training_mode):
+                model = self.remove_unused_nodes(self.batchnorm_model(training_mode))
+                node = model.graph.node[0]
+                self.assertEqual(list(node.output), ["y"])
+                self.assertNotIn("training_mode", {attr.name for attr in node.attribute})
+                onnx.checker.check_model(model)
+
+    def test_preserve_batchnorm_graph_outputs(self):
+        model = self.batchnorm_model(training_mode=0, include_running_outputs=True)
+        model = self.remove_unused_nodes(model)
+        node = model.graph.node[0]
+        self.assertEqual(list(node.output), ["y", "running_mean", "running_var"])
+        onnx.checker.check_model(model)
+
+    def test_preserve_batchnorm_with_referenced_training_mode(self):
+        inputs = [ir.Value(name=name) for name in ("x", "scale", "bias", "mean", "var")]
+        batch_norm = ir.node(
+            "BatchNormalization",
+            inputs=inputs,
+            attributes={
+                "training_mode": ir.RefAttr(
+                    "training_mode", "training_mode", ir.AttributeType.INT
+                )
+            },
+            num_outputs=3,
+        )
+        for output, name in zip(batch_norm.outputs, ("y", "running_mean", "running_var")):
+            output.name = name
+        function = ir.Function(
+            domain="test",
+            name="BatchNorm",
+            graph=ir.Graph(
+                inputs,
+                [batch_norm.outputs[0]],
+                nodes=[batch_norm],
+                opset_imports={"": 17},
+                name="function",
+            ),
+            attributes=[ir.Attr("training_mode", ir.AttributeType.UNDEFINED, None)],
+        )
+        model = ir.Model(
+            ir.Graph([], [], nodes=[], opset_imports={"": 17}, name="main"),
+            ir_version=10,
+            functions=[function],
+        )
+
+        onnx_ir.passes.common.RemoveUnusedNodesPass()(model)
+
+        self.assertEqual(
+            [output.name for output in batch_norm.outputs],
+            ["y", "running_mean", "running_var"],
+        )
+        training_mode = batch_norm.attributes["training_mode"]
+        self.assertTrue(training_mode.is_ref())
+        self.assertEqual(training_mode.ref_attr_name, "training_mode")
+        onnx.checker.check_model(ir.serde.serialize_model(model))
 
 
 class RemoveUnusedFunctionsTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- for `BatchNormalization` schemas that define `training_mode` (opset 14+), preserve the attribute and all three outputs unless inference mode is statically known
- remove trailing unused outputs only when modern `training_mode` is absent or a concrete integer `0`
- preserve all optional outputs for legacy schemas, where output arity itself selects training versus inference behavior
- preserve referenced or otherwise unresolved `training_mode` attributes conservatively

## Root cause
`RemoveUnusedNodesPass` treated unused running-statistics outputs as proof that a `BatchNormalization` node could be changed to inference mode. In opset 14+, that changes `Y`: training mode normalizes with current batch statistics, while inference mode uses `input_mean` and `input_var`.

Before opset 14, `training_mode` does not exist. In opsets 7-13, a five-output node selects training behavior while a one-output node selects inference behavior, so trimming unused outputs can likewise change `Y`. The pass now cleans outputs only for schemas that define `training_mode` and leaves legacy BatchNormalization nodes unchanged. Graph and function outputs continue to count as uses.

Related context:
- https://github.com/microsoft/onnxscript/issues/2969
- https://github.com/microsoft/onnxscript/pull/2988

## Validation
- `python -m pytest src\onnx_ir\passes\common\unused_removal_test.py -q` (26 passed)
- `lintrunner --output oneline src\onnx_ir\passes\common\unused_removal.py src\onnx_ir\passes\common\unused_removal_test.py`
- ONNX checker validation for modern and opset-9 models
- numerical regressions for opset-17 training mode with ONNX ReferenceEvaluator and opset-9 arity-based training with ONNX Runtime